### PR TITLE
Fix extra backtick in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-A Conda recipe for [CppUTest](https://cpputest.github.io/). This installs 
-CppUTest into the `$CONDA_PREFIX/lib` and `$CONDA_PREFIX`/include` directories. 
+A Conda recipe for [CppUTest](https://cpputest.github.io/). This installs
+CppUTest into the `$CONDA_PREFIX/lib` and `$CONDA_PREFIX/include` directories.
 
 
-It also exports the appropriate `$CPPUTEST_HOME` variable to the environment when 
+It also exports the appropriate `$CPPUTEST_HOME` variable to the environment when
 the Conda environment is activated.


### PR DESCRIPTION
Just FYI there's also a typo in the repo description: `treater` --> `greater` ;)