### PR TITLE
MFLT-5638 cmake recipe for expat version conflict

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,0 +1,51 @@
+# cmake.memfault
+
+This is a copy-paste of the recipe from here:
+
+https://github.com/conda-forge/cmake-feedstock/tree/284e91676110b5d52130bd6fb04e91f099194fcf/recipe
+
+The conda-forge versions of `cmake` (https://anaconda.org/conda-forge/cmake/)
+specify a more recent `expat` dependency than what we used in some of our
+in-house packages:
+
+```bash
+❯ rg 'expat:\s+- 2\.2' --multiline
+gdb-xtensa-esp32-elf/conda_build_config.yaml
+367:expat:
+368:  - 2.2
+
+gdb-multi-arch/conda_build_config.yaml
+367:expat:
+368:  - 2.2
+
+gdb-arm-elf-linux/conda_build_config.yaml
+20:expat:
+21:  - 2.2
+
+redis/conda_build_config.yaml
+367:expat:
+368:  - 2.2
+
+gdb-xtensa-lx106-elf/conda_build_config.yaml
+367:expat:
+368:  - 2.2
+
+cpputest/conda_build_config.yaml
+367:expat:
+368:  - 2.2
+```
+
+Those were using a particular version of the pinning file from here:
+
+https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml
+
+Which over-specified expat to `'2.2'` at the time. Now (as of 2022-03-08) it's
+been updated to `'2'`, which would be OK if the `max_pin` setting was set to `x`
+for expat, but it's not specified, and ends up over-constrained to the max
+`'2'`-compatible version at the time (`2.4.6` right now, up to 3).
+
+This causes incompatible packages between our in-house built ones and the
+conda-forge `cmake` versions, starting around `cmake=3.20` or so.
+
+This folder forks the recipe and sets the `expat` dep to `2.2` so it's
+compatible with our other packages, rather than correcting those packages.

--- a/cmake/SSLTest.cmake
+++ b/cmake/SSLTest.cmake
@@ -1,0 +1,16 @@
+set(FILE_NAME "LICENSE.txt")
+set(DOWNLOAD_URL "https://raw.githubusercontent.com/conda-forge/cmake-feedstock/968a712d28a374c73e20b8b8b0115e8027018870/${FILE_NAME}")
+set(EXPECTED_SHA256 "b5904c52eaee178d332cc0cb2e3795f68af62a72bfb090ea32c493abd88af0d6")
+
+file(DOWNLOAD ${DOWNLOAD_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
+ SHOW_PROGRESS
+ EXPECTED_HASH  SHA256=${EXPECTED_SHA256}
+ STATUS STATUS
+ TLS_VERIFY on )
+
+list( GET STATUS 0 RET )
+list( GET STATUS 1 MESSAGE )
+
+if( NOT RET EQUAL 0 )
+  message(FATAL "Error Downloading file: ${MESSAGE}")
+endif()

--- a/cmake/bld.bat
+++ b/cmake/bld.bat
@@ -1,0 +1,28 @@
+
+if "%ARCH%"=="32" (set CPU_ARCH=x86) else (set CPU_ARCH=x64)
+curl https://cmake.org/files/v%PKG_VERSION:~0,4%/cmake-%PKG_VERSION%-win%ARCH%-%CPU_ARCH%.zip -o cmake-win.zip
+7z x cmake-win.zip > nil
+set PATH=%CD%\cmake-%PKG_VERSION%-win%ARCH%-%CPU_ARCH%\bin;%PATH%
+cmake --version
+
+mkdir build && cd build
+
+set CMAKE_CONFIG="Release"
+
+dir /p %LIBRARY_PREFIX%\lib
+
+
+cmake -LAH -G"NMake Makefiles"                               ^
+    -DCMAKE_BUILD_TYPE=%CMAKE_CONFIG%                        ^
+    -DCMAKE_FIND_ROOT_PATH="%LIBRARY_PREFIX%"                ^
+    -DCMAKE_PREFIX_PATH="%PREFIX%"                           ^
+    -DCMAKE_CXX_STANDARD:STRING=17                           ^
+    -DCMake_HAVE_CXX_MAKE_UNIQUE:INTERNAL=TRUE               ^
+    -DCMAKE_USE_SCHANNEL:BOOL=ON                             ^
+    -DCURL_WINDOWS_SSPI:BOOL=ON                              ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ..
+if errorlevel 1 exit 1
+
+cmake --build . --config %CMAKE_CONFIG% --target install
+if errorlevel 1 exit 1
+

--- a/cmake/build.sh
+++ b/cmake/build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -ex
+
+CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_FIND_ROOT_PATH=${PREFIX} -DCMAKE_INSTALL_RPATH=${PREFIX}/lib"
+CMAKE_ARGS="$CMAKE_ARGS -DCURSES_INCLUDE_PATH=${PREFIX}/include -DBUILD_CursesDialog=ON -DCMake_HAVE_CXX_MAKE_UNIQUE:INTERNAL=FALSE"
+CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=${PREFIX}"
+
+if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
+   if [[ "$target_platform" == osx-* ]] && [[ "$MACOSX_DEPLOYMENT_TARGET" == 11.* || "$MACOSX_DEPLOYMENT_TARGET" == "10.15" ]]; then
+       CMAKE_ARGS="$CMAKE_ARGS -DCMake_HAVE_CXX_FILESYSTEM=1"
+   else
+       CMAKE_ARGS="$CMAKE_ARGS -DCMake_HAVE_CXX_FILESYSTEM=0"
+   fi
+   cmake ${CMAKE_ARGS} \
+       -DCMAKE_VERBOSE_MAKEFILE=1 \
+       -DCMAKE_INSTALL_PREFIX=$PREFIX \
+       -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
+       -DBUILD_QtDialog=OFF \
+       -DCMAKE_USE_SYSTEM_LIBRARY_LIBARCHIVE=OFF \
+       -DCMAKE_USE_SYSTEM_LIBRARY_JSONCPP=OFF \
+       . || (cat TryRunResults.cmake; false)
+else
+  ./bootstrap \
+       --verbose \
+       --prefix="${PREFIX}" \
+       --system-libs \
+       --no-qt-gui \
+       --no-system-libarchive \
+       --no-system-jsoncpp \
+       --parallel=${CPU_COUNT} \
+       -- \
+       ${CMAKE_ARGS}
+fi
+
+# CMake automatically selects the highest C++ standard available
+
+make install -j${CPU_COUNT}
+

--- a/cmake/conda_build_config.yaml
+++ b/cmake/conda_build_config.yaml
@@ -1,0 +1,58 @@
+CI: azure
+bzip2: '1'
+c_compiler: gcc
+c_compiler_version: '9'
+cdt_name: cos6
+channel_sources: conda-forge,defaults
+channel_targets: conda-forge main
+cpu_optimization_target: nocona
+cran_mirror: https://cran.r-project.org
+cxx_compiler: gxx
+cxx_compiler_version: '9'
+docker_image: quay.io/condaforge/linux-anvil-comp7
+
+# specify an expat version compatible with our other recipes with expat: '2.2'
+expat: '2.2'
+
+extend_keys:
+- ignore_build_only_deps
+- extend_keys
+- ignore_version
+- pin_run_as_build
+fortran_compiler: gfortran
+ignore_build_only_deps:
+- numpy
+- python
+libcurl: '7'
+lua: '5'
+ncurses: '6.2'
+numpy: '1.16'
+perl: 5.26.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+  bzip2:
+    max_pin: x
+  libcurl:
+    max_pin: x
+  ncurses:
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+python: '3.8'
+r_base: '3.5'
+target_platform: linux-64
+xz: '5.2'
+zip_keys:
+- - cdt_name
+  - docker_image
+- - c_compiler_version
+  - cxx_compiler_version
+zlib: '1.2'
+zstd: '1.5'

--- a/cmake/meta.yaml
+++ b/cmake/meta.yaml
@@ -1,0 +1,94 @@
+{% set version = "3.21.3" %}
+
+package:
+  name: cmake
+  version: {{ version }}.memfault0
+
+source:
+  url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}.tar.gz
+  sha256: d14d06df4265134ee42c4d50f5a60cb8b471b7b6a47da8e5d914d49dd783794f
+  # Not until Python 3.8 on Windows: https://github.com/WorksApplications/SudachiPy/issues/107#issuecomment-564510365
+  # path: 'C:/opt/Shared.local/src/cmake'
+  # path_via_symlink: True
+  # folder: cmake
+  # git_url: 'C:/opt/Shared.local/src/cmake'
+  # git_url: 'https://gitlab.kitware.com/cmake/cmake'
+  # patches:
+  #   - patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
+
+build:
+  number: 0
+  ignore_run_exports:
+    - vc
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make            # [unix]
+    - patch           # [not win]
+    - m2-patch        # [win]
+    - cmake           # [build_platform != target_platform]
+    # - git
+
+  host:
+    - bzip2           # [unix]
+    - libcurl         # [unix]
+    - expat           # [unix]
+    - ncurses         # [unix]
+    - xz              # [unix]
+    - zlib            # [unix]
+    - libuv           # [unix]
+    - rhash           # [unix]
+    - zstd            # [unix]
+
+  run:
+    - bzip2           # [unix]
+    - libcurl         # [unix]
+    - expat           # [unix]
+    - ncurses         # [unix]
+    - xz              # [unix]
+    - zlib            # [unix]
+    - libuv           # [unix]
+    - rhash           # [unix]
+    - zstd            # [unix]
+    - vs2015_runtime  # [win]
+
+test:
+  files:
+    - SSLTest.cmake
+  commands:
+    - cmake --version
+    - cmake -V -P SSLTest.cmake
+    - ctest --version
+    - cpack --version
+    - ccmake --version  # [unix]
+
+about:
+  home: http://www.cmake.org/
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file:
+    - Copyright.txt
+    - Utilities/cmbzip2/LICENSE         # [win]
+    - Utilities/cmcurl/COPYING          # [win]
+    - Utilities/cmexpat/COPYING         # [win]
+    - Utilities/cmliblzma/COPYING       # [win]
+    - Utilities/cmzlib/Copyright.txt    # [win]
+    - Utilities/cmlibuv/LICENSE         # [win]
+    - Utilities/cmlibrhash/COPYING      # [win]
+    - Utilities/cmlibarchive/COPYING
+    - Utilities/cmjsoncpp/LICENSE
+  summary: CMake is an extensible, open-source system that manages the build process
+
+extra:
+  recipe-maintainers:
+    - blowekamp
+    - groutr
+    - jakirkham
+    - jschueller
+    - ocefpaf
+    - msarahan
+    - scopatz
+    - tadeu
+    - marcelotrevisani

--- a/cmake/patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
+++ b/cmake/patches/git/0001-Add-more-debug-logging-to-cmFindCommon.patch
@@ -1,0 +1,218 @@
+From 3013a6c394bc3e3782d52840452cf3182fcf13ff Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Tue, 26 Feb 2019 18:18:56 +0100
+Subject: [PATCH] Add more debug logging to cmFindCommon*
+
+---
+ Help/manual/cmake.1.rst         |  3 +++
+ Source/cmFindBase.cxx           | 21 +++++++++++++++++++++
+ Source/cmFindCommon.cxx         |  6 ++++++
+ Source/cmFindCommon.h           |  4 ++++
+ Source/cmFindPackageCommand.cxx | 27 ++++++++++++++++++++++++++-
+ Source/cmServerDictionary.h     |  1 +
+ Source/cmServerProtocol.cxx     |  9 ++++++---
+ 7 files changed, 67 insertions(+), 4 deletions(-)
+
+diff --git a/Help/manual/cmake.1.rst b/Help/manual/cmake.1.rst
+index 4315f0a0b3..fd2ee0eb80 100644
+--- a/Help/manual/cmake.1.rst
++++ b/Help/manual/cmake.1.rst
+@@ -238,6 +238,9 @@ Options
+ ``--debug-output``
+  Put cmake in a debug mode.
+ 
++``--debug-find``
++ Put cmake find in a debug mode.
++
+  Print extra information during the cmake run like stack traces with
+  :command:`message(SEND_ERROR)` calls.
+ 
+diff --git a/Source/cmFindBase.cxx b/Source/cmFindBase.cxx
+index bec99bb7ee..f018f2e5af 100644
+--- a/Source/cmFindBase.cxx
++++ b/Source/cmFindBase.cxx
+@@ -130,6 +130,27 @@ bool cmFindBase::ParseArguments(std::vector<std::string> const& argsIn)
+       } else if (doing == DoingPathSuffixes) {
+         this->AddPathSuffix(args[j]);
+       }
++      if (this->ComputeIfDebugModeWanted()) {
++        std::string msg = "cmFindBase::ParseArguments added ";
++        switch (doing) {
++          case DoingNames:
++            msg += " NAME ";
++            break;
++          case DoingPaths:
++            msg += " PATH ";
++            break;
++          case DoingPathSuffixes:
++            msg += " PATHSUFFIXES ";
++            break;
++          case DoingHints:
++            msg += " HINTS ";
++            break;
++          default:
++            break;
++        }
++        msg += args[j];
++        cmFindCommon_IssueMessage(this->Makefile, msg);
++      }
+     }
+   }
+ 
+diff --git a/Source/cmFindCommon.cxx b/Source/cmFindCommon.cxx
+index 82acfedad3..b3a235e743 100644
+--- a/Source/cmFindCommon.cxx
++++ b/Source/cmFindCommon.cxx
+@@ -71,6 +71,12 @@ void cmFindCommon::DebugMessage(std::string const& msg) const
+   }
+ }
+ 
++void cmFindCommon_IssueMessage(const cmMakefile* mf, std::string const& msg)
++{
++  if (mf)
++    mf->IssueMessage(MessageType::LOG, msg);
++}
++
+ bool cmFindCommon::ComputeIfDebugModeWanted()
+ {
+   return this->Makefile->IsOn("CMAKE_FIND_DEBUG_MODE") ||
+diff --git a/Source/cmFindCommon.h b/Source/cmFindCommon.h
+index 916f3bc9ba..1c4152fbe4 100644
+--- a/Source/cmFindCommon.h
++++ b/Source/cmFindCommon.h
+@@ -144,4 +144,8 @@ protected:
+   cmExecutionStatus& Status;
+ };
+ 
++/* Convenience function (DRY) for cmFindLibraryHelper to use */
++extern void cmFindCommon_IssueMessage(const cmMakefile* mf,
++                                      std::string const& msg);
++
+ #endif
+diff --git a/Source/cmFindPackageCommand.cxx b/Source/cmFindPackageCommand.cxx
+index 9eb256b7a3..902532eba4 100644
+--- a/Source/cmFindPackageCommand.cxx
++++ b/Source/cmFindPackageCommand.cxx
+@@ -1200,26 +1200,39 @@ void cmFindPackageCommand::ComputePrefixes()
+       this->FillPrefixesPackageRoot();
+     }
+     if (!this->NoCMakePath) {
++      if (this->DebugMode)
++        this->DebugMessage("FillPrefixesCMakeVariable()\n");
+       this->FillPrefixesCMakeVariable();
+     }
+     if (!this->NoCMakeEnvironmentPath) {
++      if (this->DebugMode)
++        this->DebugMessage("FillPrefixesCMakeEnvironment()\n");
+       this->FillPrefixesCMakeEnvironment();
+     }
+   }
+ 
+   this->FillPrefixesUserHints();
+-
++  if (this->DebugMode)
++    this->DebugMessage("FillPrefixesUserHints()\n");
+   if (!this->NoDefaultPath) {
+     if (!this->NoSystemEnvironmentPath) {
++      if (this->DebugMode)
++        this->DebugMessage("FillPrefixesSystemEnvironment()\n");
+       this->FillPrefixesSystemEnvironment();
+     }
+     if (!this->NoUserRegistry) {
++      if (this->DebugMode)
++        this->DebugMessage("FillPrefixesUserRegistry()\n");
+       this->FillPrefixesUserRegistry();
+     }
+     if (!this->NoCMakeSystemPath) {
++      if (this->DebugMode)
++        this->DebugMessage("FillPrefixesCMakeSystemVariable()\n");
+       this->FillPrefixesCMakeSystemVariable();
+     }
+     if (!this->NoSystemRegistry) {
++      if (this->DebugMode)
++        this->DebugMessage("FillPrefixesSystemRegistry()\n");
+       this->FillPrefixesSystemRegistry();
+     }
+   }
+@@ -2148,6 +2161,10 @@ private:
+ bool cmFindPackageCommand::SearchPrefix(std::string const& prefix_in)
+ {
+   assert(!prefix_in.empty() && prefix_in.back() == '/');
++  if (this->DebugMode) {
++    std::string msg = "Checking prefix [" + prefix_in + "]\n";
++    this->DebugMessage(msg);
++  }
+ 
+   // Skip this if the prefix does not exist.
+   if (!cmSystemTools::FileIsDirectory(prefix_in)) {
+@@ -2301,6 +2318,10 @@ bool cmFindPackageCommand::SearchPrefix(std::string const& prefix_in)
+ bool cmFindPackageCommand::SearchFrameworkPrefix(std::string const& prefix_in)
+ {
+   assert(!prefix_in.empty() && prefix_in.back() == '/');
++  if (this->DebugMode) {
++    std::string msg = "Checking framework prefix [" + prefix_in + "]\n";
++    this->DebugMessage(msg);
++  }
+ 
+   // Strip the trailing slash because the path generator is about to
+   // add one.
+@@ -2359,6 +2380,10 @@ bool cmFindPackageCommand::SearchFrameworkPrefix(std::string const& prefix_in)
+ bool cmFindPackageCommand::SearchAppBundlePrefix(std::string const& prefix_in)
+ {
+   assert(!prefix_in.empty() && prefix_in.back() == '/');
++  if (this->DebugMode) {
++    std::string msg = "Checking bundle prefix [" + prefix_in + "]\n";
++    this->DebugMessage(msg);
++  }
+ 
+   // Strip the trailing slash because the path generator is about to
+   // add one.
+diff --git a/Source/cmServerDictionary.h b/Source/cmServerDictionary.h
+index 961e4b7ea8..f452c13ad4 100644
+--- a/Source/cmServerDictionary.h
++++ b/Source/cmServerDictionary.h
+@@ -33,6 +33,7 @@ static const std::string kCHECK_SYSTEM_VARS_KEY = "checkSystemVars";
+ static const std::string kCMAKE_ROOT_DIRECTORY_KEY = "cmakeRootDirectory";
+ static const std::string kCOOKIE_KEY = "cookie";
+ static const std::string kDEBUG_OUTPUT_KEY = "debugOutput";
++static const std::string kDEBUG_FIND_OUTPUT_KEY = "debugFindOutput";
+ static const std::string kERROR_MESSAGE_KEY = "errorMessage";
+ static const std::string kEXTRA_GENERATOR_KEY = "extraGenerator";
+ static const std::string kGENERATOR_KEY = "generator";
+diff --git a/Source/cmServerProtocol.cxx b/Source/cmServerProtocol.cxx
+index 56003df75f..cf5d993f01 100644
+--- a/Source/cmServerProtocol.cxx
++++ b/Source/cmServerProtocol.cxx
+@@ -634,6 +634,7 @@ cmServerResponse cmServerProtocol1::ProcessGlobalSettings(
+   obj[kCAPABILITIES_KEY] = cm->ReportCapabilitiesJson();
+ 
+   obj[kDEBUG_OUTPUT_KEY] = cm->GetDebugOutput();
++  obj[kDEBUG_FIND_OUTPUT_KEY] = cm->GetDebugFindOutput();
+   obj[kTRACE_KEY] = cm->GetTrace();
+   obj[kTRACE_EXPAND_KEY] = cm->GetTraceExpand();
+   obj[kWARN_UNINITIALIZED_KEY] = cm->GetWarnUninitialized();
+@@ -664,9 +665,9 @@ cmServerResponse cmServerProtocol1::ProcessSetGlobalSettings(
+   const cmServerRequest& request)
+ {
+   const std::vector<std::string> boolValues = {
+-    kDEBUG_OUTPUT_KEY,       kTRACE_KEY,       kTRACE_EXPAND_KEY,
+-    kWARN_UNINITIALIZED_KEY, kWARN_UNUSED_KEY, kWARN_UNUSED_CLI_KEY,
+-    kCHECK_SYSTEM_VARS_KEY
++    kDEBUG_OUTPUT_KEY,    kDEBUG_FIND_OUTPUT_KEY,  kTRACE_KEY,
++    kTRACE_EXPAND_KEY,    kWARN_UNINITIALIZED_KEY, kWARN_UNUSED_KEY,
++    kWARN_UNUSED_CLI_KEY, kCHECK_SYSTEM_VARS_KEY
+   };
+   for (std::string const& i : boolValues) {
+     if (!request.Data[i].isNull() && !request.Data[i].isBool()) {
+@@ -679,6 +680,8 @@ cmServerResponse cmServerProtocol1::ProcessSetGlobalSettings(
+ 
+   setBool(request, kDEBUG_OUTPUT_KEY,
+           [cm](bool e) { cm->SetDebugOutputOn(e); });
++  setBool(request, kDEBUG_FIND_OUTPUT_KEY,
++          [cm](bool e) { cm->SetDebugFindOutputOn(e); });
+   setBool(request, kTRACE_KEY, [cm](bool e) { cm->SetTrace(e); });
+   setBool(request, kTRACE_EXPAND_KEY, [cm](bool e) { cm->SetTraceExpand(e); });
+   setBool(request, kWARN_UNINITIALIZED_KEY,
+-- 
+2.24.1
+


### PR DESCRIPTION
The conda-forge cmake package has cmake requirement of:

`expat >=2.4.1,<3.0a0`

This conflicts with our internally built gdb packages, which are
(incorrectly) set to ^2.2:

`expat >=2.2.10,<2.3.0a0`

It's simpler to just fork cmake especially since we only use it in
testing, not in production.

Recipe taken from here:

https://github.com/conda-forge/cmake-feedstock/tree/284e91676110b5d52130bd6fb04e91f099194fcf/recipe

Only modification is to specify `expat: '2.2'` instead of `expat: '2'`.