### PR TITLE
Add github action for opt-in building linux+osx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+on: pull_request
+
+env:
+  # set package dir to build and archive your package
+  PACKAGE_DIR: ''
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-20.04, macos-11]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v2
+      # sadly, can't use env at the 'job' level, so have to gate each step
+      # individually 🙄
+      # https://github.community/t/how-to-set-and-access-a-workflow-variable/17335
+      if: ${{ env.PACKAGE_DIR != '' }}
+
+    - name: Install conda-build
+      if: ${{ env.PACKAGE_DIR != '' }}
+      run: |
+        conda install conda-build=3.21.4
+
+    - name: Build package
+      if: ${{ env.PACKAGE_DIR != '' }}
+      run: |
+        mkdir -p ${{ env.PACKAGE_DIR }}/output
+        conda build -c conda-forge --output-folder ${{ env.PACKAGE_DIR }}/output ${{ env.PACKAGE_DIR }}
+
+    # upload-artifact to save the output files
+    - uses: actions/upload-artifact@v2
+      if: ${{ env.PACKAGE_DIR != '' }}
+      with:
+        name: packages
+        path: ${{ env.PACKAGE_DIR }}/output

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ channels:
 
 Since all of these packages are built using Conda Forge's package pinnings (https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml), using Conda Forge as the base is heavily suggested.
 
-## Building
+## Building Locally
 
 To build any of the following packages (macOS and Linux Ubuntu 18.04 tested):
 
@@ -35,7 +35,7 @@ $ anaconda upload ...
 
 ### Docker for Linux
 
-So you don't want to build on your native machine? That's fine! 
+So you don't want to build on your native machine? That's fine!
 
 ```
 $ docker run -ti -v <path_to_conda-recipes>:/conda-recipes condaforge/miniforge3  /bin/bash
@@ -65,3 +65,14 @@ To download and install this SDK, you can find the package here: https://github.
 ```
 $ sudo mv <10.9 SDK> /opt/MacOSX10.9.sdk
 ```
+
+## Building via GitHub Action
+
+Not heavily tested, but it's possible to build packages from github actions, see
+[`.github/workflows/build.yml`](.github/workflows/build.yml).
+
+To trigger it, set the appropriate `PACKAGE_DIR` when making a pull request.
+
+Note that this may not work if the above `CONDA_BUILD_SYSROOT` is set; you'll
+have to add a step to install the appropriate tools into that location if you
+want to go that route.

--- a/cmake/conda_build_config.yaml
+++ b/cmake/conda_build_config.yaml
@@ -1,14 +1,25 @@
 CI: azure
 bzip2: '1'
-c_compiler: gcc
-c_compiler_version: '9'
+
+# override the defaults here so we can build for osx too.
+c_compiler:
+  - gcc                        # [linux]
+  - clang                      # [osx]
+c_compiler_version:            # [unix]
+  - 12                         # [osx]
+  - 10                         # [linux]
+cxx_compiler:
+  - gxx                        # [linux]
+  - clangxx                    # [osx]
+cxx_compiler_version:          # [unix]
+  - 12                         # [osx]
+  - 10                         # [linux]
+
 cdt_name: cos6
 channel_sources: conda-forge,defaults
 channel_targets: conda-forge main
 cpu_optimization_target: nocona
 cran_mirror: https://cran.r-project.org
-cxx_compiler: gxx
-cxx_compiler_version: '9'
 docker_image: quay.io/condaforge/linux-anvil-comp7
 
 # specify an expat version compatible with our other recipes with expat: '2.2'
@@ -47,7 +58,6 @@ pin_run_as_build:
     max_pin: x.x
 python: '3.8'
 r_base: '3.5'
-target_platform: linux-64
 xz: '5.2'
 zip_keys:
 - - cdt_name


### PR DESCRIPTION
It's a bummer trying to cross build for osx on linux 😣. Add a github
action that uses the github-hosted macos runner for building osx conda
packages.

It's opt-in, have to set the package dir to enable it in a pull request.

May not work well with the places we've set `CONDA_BUILD_SYSROOT` (noted
in the readme).

---

Second change in a separate commit for fixing the cmake recipe for osx.