### PR TITLE
Fix broken gdb 12.1 mac binary

### DIFF
--- a/gdb-multi-arch/build.sh
+++ b/gdb-multi-arch/build.sh
@@ -22,6 +22,7 @@ export CFLAGS="$CFLAGS -Wno-constant-logical-operand -Wno-format-nonliteral -Wno
     --with-expat \
     --with-libexpat-prefix="$PREFIX" \
     --with-libiconv-prefix="$PREFIX" \
+    --without-guile \
     --without-libunwind-ia64 \
     --with-zlib \
     --without-babeltrace \

--- a/gdb-multi-arch/meta.yaml
+++ b/gdb-multi-arch/meta.yaml
@@ -14,7 +14,7 @@ source:
       - mac-build-fix.patch  # [osx]
 
 build:
-  number: '0'
+  number: '1'
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Need to remove libguile dependency for mac. Guile is a scheme-like
scripting language extension to gdb that we don't use.