### PR TITLE
Fix actions output: don't accumulate output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ubuntu-20.04, macos-11, windows-2022]
+        platform: [ubuntu-20.04, macos-11,]  #  windows-2022] windows is a bit sad :'(
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -28,17 +28,18 @@ jobs:
       - name: Conda info
         run: conda info
 
-      - name: Install conda-build
+      - name: Install mambabuild
         run: |
-          conda install conda-build=3.21.4
+          mamba install --channel conda-forge boa==0.11.0
 
       - name: Build package
         run: |
-          mkdir -p ${{ github.event.inputs.PACKAGE_DIR }}/output
-          conda build -c conda-forge --output-folder ${{ github.event.inputs.PACKAGE_DIR }}/output ${{ github.event.inputs.PACKAGE_DIR }}
+          # store the output in an out of tree location
+          mkdir -p ${{ github.event.inputs.PACKAGE_DIR }}.output
+          conda mambabuild -c conda-forge --output-folder ${{ github.event.inputs.PACKAGE_DIR }}.output ${{ github.event.inputs.PACKAGE_DIR }}
 
       # upload-artifact to save the output files
       - uses: actions/upload-artifact@v2
         with:
           name: packages
-          path: ${{ github.event.inputs.PACKAGE_DIR }}/output
+          path: ${{ github.event.inputs.PACKAGE_DIR }}.output


### PR DESCRIPTION
Issue with the output folder being located in the recipe directory,
which caused each python variant to include the previous output.

Change the output directory, which fixes #15

Switch to `mambabuild`, which is ✨faster✨.

Also remove windows from the build matrix, doesn't really work well