### PR TITLE
Add patch for fixing GDB's disassemble for v10+

### DIFF
--- a/gdb-multi-arch/fix-disassemble-segfault.patch
+++ b/gdb-multi-arch/fix-disassemble-segfault.patch
@@ -1,0 +1,25 @@
+From f4d2522f60022dca9922193d960ff72c0ed4a7d4 Mon Sep 17 00:00:00 2001
+From: Tyler Hoffman <tyler@memfault.com>
+Date: Fri, 22 Jul 2022 14:38:56 -0700
+Subject: [PATCH] Fix disassemble segfault - check symtab size
+
+---
+ opcodes/arm-dis.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/opcodes/arm-dis.c b/opcodes/arm-dis.c
+index 92cd098d6c..c0789c4e1b 100644
+--- a/opcodes/arm-dis.c
++++ b/opcodes/arm-dis.c
+@@ -11846,7 +11846,7 @@ mapping_symbol_for_insn (bfd_vma pc, struct disassemble_info *info,
+     type = MAP_ARM;
+   struct arm_private_data *private_data;
+ 
+-  if (info->private_data == NULL
++  if (info->private_data == NULL  || info->symtab_size == 0
+       || bfd_asymbol_flavour (*info->symtab) != bfd_target_elf_flavour)
+     return false;
+ 
+-- 
+2.36.0
+

--- a/gdb-multi-arch/meta.yaml
+++ b/gdb-multi-arch/meta.yaml
@@ -10,11 +10,12 @@ source:
   - url: https://github.com/bminor/binutils-gdb/archive/gdb-{{ version }}-release.tar.gz
     sha256: {{ sha256 }}
     patches:
+      - fix-disassemble-segfault.patch
       # mac doesn't build without this patch
       - mac-build-fix.patch  # [osx]
 
 build:
-  number: '1'
+  number: '2'
   skip: True  # [win]
 
 requirements:

--- a/gdb-xtensa-esp32-elf/fix-disassemble-segfault.patch
+++ b/gdb-xtensa-esp32-elf/fix-disassemble-segfault.patch
@@ -1,0 +1,25 @@
+From f4d2522f60022dca9922193d960ff72c0ed4a7d4 Mon Sep 17 00:00:00 2001
+From: Tyler Hoffman <tyler@memfault.com>
+Date: Fri, 22 Jul 2022 14:38:56 -0700
+Subject: [PATCH] Fix disassemble segfault - check symtab size
+
+---
+ opcodes/arm-dis.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/opcodes/arm-dis.c b/opcodes/arm-dis.c
+index 92cd098d6c..c0789c4e1b 100644
+--- a/opcodes/arm-dis.c
++++ b/opcodes/arm-dis.c
+@@ -11846,7 +11846,7 @@ mapping_symbol_for_insn (bfd_vma pc, struct disassemble_info *info,
+     type = MAP_ARM;
+   struct arm_private_data *private_data;
+ 
+-  if (info->private_data == NULL
++  if (info->private_data == NULL  || info->symtab_size == 0
+       || bfd_asymbol_flavour (*info->symtab) != bfd_target_elf_flavour)
+     return false;
+ 
+-- 
+2.36.0
+

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -11,12 +11,13 @@ source:
     folder: binutils-gdb-esp32-src
     patches:
       - backtrace-fix.patch
+      - fix-disassemble-segfault.patch
   - git_url: https://github.com/espressif/crosstool-NG.git
     git_rev: esp32-2019r1-rc2
     folder: crosstool-NG-esp32
 
 build:
-  number: '0'
+  number: '2'
   skip: True  # [win]
 
 requirements:

--- a/gdb-xtensa-lx106-elf/fix-disassemble-segfault.patch
+++ b/gdb-xtensa-lx106-elf/fix-disassemble-segfault.patch
@@ -1,0 +1,25 @@
+From f4d2522f60022dca9922193d960ff72c0ed4a7d4 Mon Sep 17 00:00:00 2001
+From: Tyler Hoffman <tyler@memfault.com>
+Date: Fri, 22 Jul 2022 14:38:56 -0700
+Subject: [PATCH] Fix disassemble segfault - check symtab size
+
+---
+ opcodes/arm-dis.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/opcodes/arm-dis.c b/opcodes/arm-dis.c
+index 92cd098d6c..c0789c4e1b 100644
+--- a/opcodes/arm-dis.c
++++ b/opcodes/arm-dis.c
+@@ -11846,7 +11846,7 @@ mapping_symbol_for_insn (bfd_vma pc, struct disassemble_info *info,
+     type = MAP_ARM;
+   struct arm_private_data *private_data;
+ 
+-  if (info->private_data == NULL
++  if (info->private_data == NULL  || info->symtab_size == 0
+       || bfd_asymbol_flavour (*info->symtab) != bfd_target_elf_flavour)
+     return false;
+ 
+-- 
+2.36.0
+

--- a/gdb-xtensa-lx106-elf/meta.yaml
+++ b/gdb-xtensa-lx106-elf/meta.yaml
@@ -11,12 +11,13 @@ source:
     folder: binutils-gdb-lx106-src
     patches:
       - backtrace-fix.patch
+      - fix-disassemble-segfault.patch
   - git_url: https://github.com/espressif/xtensa-overlays.git
     git_rev: cc893dc572ff4d2e22aa5a55188fea4722a58027
     folder: xtensa-overlays
 
 build:
-  number: '0'
+  number: '2'
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
### Get Conda to build me GDB with symbols

I didn't really want to create an environment that could properly build GDB for my Mac machine, so I let Conda do it.
I inserted an `exit 1` in the `build.sh` script so that it failed at the exact time. When a Conda build fails, it leaves the work directly alone so that a developer can `cd` into it and debug it.

Upon building the GDB, the gdb binary will be located at `....../work/gdb/gdb`

### Debugging

So you can debug it with our local GDB and tell it to load the symbol file which breaks:
```
$ cd $HOME/mambaforge/envs/build/conda-bld/multi-arch-gdb_1658520479521/work/gdb/
$ /usr/local/bin/gdb --args ./gdb $HOME/dev/memfault/memfault/tools/tests/fixtures/binaries/symbols/heap-analyzer-example.elf

# Now run it
(gdb) run

# ... nested GDB now

(gdb) disassemble 0x8003c44,+2
```

The line it was segfaulting on was https://github.com/bminor/binutils-gdb/blob/master/opcodes/arm-dis.c#L11867-L11868.
Turns out that `info->symtab` was NULL, and it was dereferencing that pointer.

### WHY!?

In a change from 3 years ago, apparently there was a check for this `symtab` being NULL (rather checking `symtab_size == 0`, but same thing), but it was removed in this commit.

https://github.com/bminor/binutils-gdb/commit/796d6298bb11deab06814cc38cfe74a1bfc57551#diff-d2da7fc6562c73a3b97a5f9eaf58d5aad41e997853c8ace07c532a04365f61ccR6371

Adding it back, everything seems to work again for us. So my short term solution is just to create a patch with this back in place and say ship it.