### PR TITLE
Add recipe for elfutils

### DIFF
--- a/elfutils/README.md
+++ b/elfutils/README.md
@@ -1,0 +1,9 @@
+# elfutils
+
+Recipe copied from:
+
+https://github.com/conda-forge/elfutils-feedstock/tree/098a0d58f763ab579e23b25b6abee8ce5e3135e8
+
+We need a package that can be _installed_ on osx, even though it's non-trivial
+to actually build a working elfutils for osx. The osx version of this package is
+just a single shell script that returns non-zero.

--- a/elfutils/build.sh
+++ b/elfutils/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# On mac, just add a script that returns non-zero. On linux build the actual
+# utility.
+
+if [ `uname` == Darwin ]; then
+    mkdir -p $PREFIX/bin
+
+    echo "#!/usr/bin/env bash
+echo 'error: eu-unstrip not available for mac'
+exit 2
+" > $PREFIX/bin/eu-unstrip
+    chmod +x $PREFIX/bin/eu-unstrip
+else
+    export LIBS="$(pkg-config --libs-only-l zlib) $LIBS"
+    export LDFLAGS="$(pkg-config --libs-only-L zlib) -lrt $LDFLAGS"
+    export CFLAGS="$(pkg-config --cflags zlib) -Wno-unused-but-set-variable -Wno-unused-variable -Wno-null-dereference $CFLAGS"
+    ./configure --prefix=$PREFIX --with-zlib --enable-libdebuginfod=dummy || (cat config.log && exit 1)
+    make -j${CPU_COUNT}
+
+    # Unfortunately some tests fail, so we can't run "make check" here.
+    # This is probably due to this package being a very sensitive package.
+    # I believe this happens because it is not ready to be packaged into
+    # an environment such as conda where it will run in different OSes,
+    # environments, etc.
+    #
+    # For example, when running the tests on my personal machine, using
+    # the docker image provided by condaforge, 8 tests failed, while in
+    # CircleCI, 4 tests failed.
+
+    make install
+fi

--- a/elfutils/meta.yaml
+++ b/elfutils/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "0.187" %}
+
+package:
+  name: elfutils
+  version: {{ version }}.memfault0
+
+source:
+  fn: elfutils-{{ version }}.tar.bz2
+  url: https://fedorahosted.org/releases/e/l/elfutils/{{ version }}/elfutils-{{ version }}.tar.bz2
+  sha256: e70b0dfbe610f90c4d1fe0d71af142a4e25c3c4ef9ebab8d2d72b65159d454c8
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage('elfutils', max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}  # [linux]
+    - {{ compiler('cxx') }}  # [linux]
+    - pkg-config  # [linux]
+    - make  # [linux]
+  host:
+    - bzip2  # [linux]
+    - libarchive  # [linux]
+    - libcurl  # [linux]
+    - libmicrohttpd  # [linux]
+    - m4  # [linux]
+    - sqlite  # [linux]
+    - xz  # [linux]
+    - zlib  # [linux]
+    - zstd  # [linux]
+
+test:
+# Currently disabled
+#   requires:
+#     - {{ compiler('c') }}
+#     - pkg-config
+
+about:
+  home: https://fedorahosted.org/elfutils/
+  license: LGPL-3.0-only
+  license_file: COPYING-LGPLV3
+  summary: a set of utilities and libraries for handling ELF (Executable and Linkable Format) files.
+
+extra:
+  recipe-maintainers:
+    - edisongustavo
+    - xhochy
+  memfault-recipe-repo:
+    - https://github.com/memfault/conda-recipes/tree/master/elfutils

--- a/elfutils/run_test.sh
+++ b/elfutils/run_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+if [ `uname` == Darwin ]; then
+    set +e
+    # just confirm the script properly errors
+    eu-unstrip;
+    if [ $? -ne 2 ]; then
+        echo "error: eu-unstrip should have returned error code 2!"
+        exit 1
+    fi
+else
+    eu-addr2line --help
+    eu-ar --help
+    eu-elfcmp --help
+    eu-findtextrel --help
+    eu-nm --help
+    eu-objdump --help
+    eu-ranlib --help
+    eu-size --help
+    eu-strings --help
+    eu-strip --help
+    eu-unstrip --help
+
+    # This currently fails for various reasons:
+    #   Package zlib was not found in the pkg-config search path.
+    #   Perhaps you should add the directory containing `zlib.pc'
+    #   to the PKG_CONFIG_PATH environment variable
+    #   Package 'zlib', required by 'libelf', not found
+    #   /tmp/tmpdtkbtwmh/info/recipe/test_libdwarf.c:1:10: fatal error: elfutils/libdw.h: No such file or directory
+    #       1 | #include <elfutils/libdw.h>
+    #         |          ^~~~~~~~~~~~~~~~~~
+    #
+    # Skip this test for now. We don't use libdw, only unstrip, at the moment
+
+    # eval "${CC} -o ./test_libdwarf $RECIPE_DIR/test_libdwarf.c $(pkg-config --cflags libdw) $(pkg-config --libs libdw)"
+    # ./test_libdwarf
+fi

--- a/elfutils/test_libdwarf.c
+++ b/elfutils/test_libdwarf.c
@@ -1,0 +1,7 @@
+#include <elfutils/libdw.h>
+#include <elfutils/libdwfl.h>
+#include <dwarf.h>
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
For publishing an osx version- note that the osx version is actually a
dead stub, but needed so we can add the package to conda. We'll work
around the missing binary in our test code.