### PR TITLE
Set channel_priority=flexible in memfault config

### DIFF
--- a/memfault-config/condarc
+++ b/memfault-config/condarc
@@ -1,6 +1,5 @@
-channel_priority: strict
+channel_priority: flexible
 channels:
-  - tyhoff17
   - memfault
   - conda-forge
   - defaults

--- a/memfault-config/meta.yaml
+++ b/memfault-config/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "memfault-config" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
We now have conda-forge and memfault packages with the same name, which
is problematic for the strict solver. Switch to flexible so it doesn't
break.
