### PR TITLE
Update gdb-xtensa-esp32-elf to latest release

### DIFF
--- a/gdb-xtensa-esp32-elf/conda_build_config.yaml
+++ b/gdb-xtensa-esp32-elf/conda_build_config.yaml
@@ -652,6 +652,7 @@ numpy:
   - 1.19
   - 1.19
   - 1.19
+  - 1.19
 occt:
   - '7.5'
 openblas:
@@ -706,9 +707,11 @@ python:
   - 3.8.* *_cpython
   - 3.9.* *_cpython
   - 3.10.* *_cpython
+  - 3.11.* *_cpython
 python_impl:
   # part of a zip_keys: python, python_impl, numpy
   - cpython   # [not (osx and arm64)]
+  - cpython
   - cpython
   - cpython
   - cpython

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "xtensa-esp32-elf-gdb" %}
-{% set version = "11.1_20220318" %}
+{% set version = "12.1_20221002" %}
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault1
+  version: {{ version }}.memfault0
 
 source:
   - git_url: https://github.com/espressif/binutils-gdb.git


### PR DESCRIPTION
Updating to the latest released version.

Thanks to espressif for fixing the submodule in the latest tag:

https://github.com/espressif/esp-idf/issues/10495
