### PR TITLE
Refresh gdb-xtensa-esp32-elf's build config .yaml

### DIFF
--- a/gdb-xtensa-esp32-elf/conda_build_config.yaml
+++ b/gdb-xtensa-esp32-elf/conda_build_config.yaml
@@ -1,16 +1,11 @@
-# This differs from target_platform in that it determines what subdir the compiler
-#    will target, not what subdir the compiler package will be itself.
-#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
-#    code on win-64 miniconda.
-cross_compiler_target_platform:  # [win]
-  - win-64                     # [win]
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
-  - vs2017                     # [win]
+  - vs2019                     # [win and x86_64]
+  - vs2022                     # [win and arm64]
 c_compiler_version:            # [unix]
-  - 10                         # [linux]
-  - 13                         # [osx]
+  - 12                         # [linux]
+  - 15                         # [osx]
   - 7                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
   - 9                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
   - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
@@ -18,24 +13,24 @@ c_compiler_version:            # [unix]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
-  - vs2017                     # [win]
+  - vs2019                     # [win and x86_64]
+  - vs2022                     # [win and arm64]
 cxx_compiler_version:          # [unix]
-  - 10                         # [linux]
-  - 13                         # [osx]
+  - 12                         # [linux]
+  - 15                         # [osx]
   - 7                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
   - 9                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
   - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
   - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
 llvm_openmp:                   # [osx]
-  - 13                         # [osx]
+  - 15                         # [osx]
 fortran_compiler:              # [unix or win64]
   - gfortran                   # [linux64 or (osx and x86_64)]
   - gfortran                   # [aarch64 or ppc64le or armv7l or s390x]
   - flang                      # [win64]
 fortran_compiler_version:      # [unix or win64]
-  - 10                         # [linux]
-  - 11                         # [osx and arm64]
-  - 9                          # [osx and x86_64]
+  - 12                         # [linux]
+  - 12                         # [osx]
   - 5                          # [win64]
   - 7                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
   - 9                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
@@ -47,27 +42,29 @@ m2w64_cxx_compiler:            # [win]
   - m2w64-toolchain            # [win]
 m2w64_fortran_compiler:        # [win]
   - m2w64-toolchain            # [win]
-CMAKE_GENERATOR:               # [win]
-  - NMake Makefiles            # [win]
 
-cuda_compiler:                 # [linux or win]
-  - nvcc                       # [linux or win]
+cuda_compiler:
+  - None
+  - nvcc                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - nvcc                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - nvcc                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - nvcc                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 cuda_compiler_version:
   - None
-  - 10.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 11.0                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 11.1                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 11.2                       # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 10.2                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11.0                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11.1                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11.2                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 cuda_compiler_version_min:
   - None                       # [osx]
-  - 10.2                       # [linux64 or win]
+  - 10.2                       # [linux64 or win64]
   - 11.2                       # [linux and (ppc64le or aarch64)]
 cudnn:
   - undefined
-  - 7                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 8                          # [(linux64 or win) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 7                          # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 8                          # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 8                          # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 8                          # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 _libgcc_mutex:
   - 0.1 conda_forge
@@ -96,6 +93,8 @@ target_goos:
   - windows                    # [win]
 target_goarch:
   - amd64                      # [x86_64]
+  - arm64                      # [arm64 or aarch64]
+  - ppc64le                    # [ppc64le]
 target_goexe:
   -                            # [unix]
   - .exe                       # [win]
@@ -113,8 +112,6 @@ macos_machine:                 # [osx]
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 11.0                       # [osx and arm64]
   - 10.9                       # [osx and x86_64]
-target_platform:               # [win]
-  - win-64                     # [win]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:
@@ -159,16 +156,27 @@ zip_keys:
     - cxx_compiler_version      # [unix]
     - fortran_compiler_version  # [unix]
     - cudnn                     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - cuda_compiler             # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cdt_name                  # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - docker_image              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
   -                             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cudnn                     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - cuda_compiler             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   -
     - python
     - numpy
     - python_impl
+  # transition until arrow_cpp can be dropped for arrow 13.x
+  -
+    - arrow_cpp
+    - libarrow
+  # until libprotobuf 3.21->4.23 migration is complete
+  -
+    - libgrpc
+    - libprotobuf
+
 
 # aarch64 specifics because conda-build sets many things to centos 6
 # this can probably be removed when conda-build gets updated defaults
@@ -182,220 +190,114 @@ BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
 cdt_arch: armv7l                          # [armv7l]
 BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
 
-# TODO: remove these when run_exports are added to the packages.
 pin_run_as_build:
-  arpack:
-    max_pin: x.x.x
+  # boost is special, see https://github.com/conda-forge/boost-cpp-feedstock/pull/82
   boost:
     max_pin: x.x.x
   boost-cpp:
     max_pin: x.x.x
-  bzip2:
-    max_pin: x
-  cairo:
-    max_pin: x.x
-  curl:
-    max_pin: x
-  dbus:
-    max_pin: x
-  fftw:
-    max_pin: x
+  # TODO: add run_exports to the following feedstocks
   flann:
     max_pin: x.x.x
-  fontconfig:
-    max_pin: x
-  freetype:
-    max_pin: x
-  gdal:
-    max_pin: x.x
-  glew:
-    max_pin: x.x
-  glpk:
-    max_pin: x.x
-  gmp:
-    max_pin: x
   graphviz:
     max_pin: x
-  harfbuzz:
-    max_pin: x
-  hdf4:
-    max_pin: x.x
-  isl:
-    max_pin: x.x
-  jasper:
-    max_pin: x
-  jpeg:
-    max_pin: x
-  libjpeg_turbo:
-    max_pin: x
-  json-c:
-    max_pin: x.x
-  jsoncpp:
-    max_pin: x.x.x
-  kealib:
-    max_pin: x.x
-  krb5:
-    max_pin: x.x
-  libblitz:
-    max_pin: x.x
-  libcurl:
-    max_pin: x
-  libevent:
-    max_pin: x.x.x
-  libffi:
-    max_pin: x.x
-  libgdal:
-    max_pin: x.x
-  libiconv:
-    max_pin: x.x
-  libkml:
-    max_pin: x.x
-  libpng:
-    max_pin: x.x
-  librsvg:
-    max_pin: x
   libsvm:
-    max_pin: x.x
-  libtiff:
-    max_pin: x
-  libxml2:
-    max_pin: x.x
-  libuuid:
-    max_pin: x
-  lzo:
-    max_pin: x
-  metis:
-    max_pin: x.x
-  mpfr:
     max_pin: x
   netcdf-cxx4:
     max_pin: x.x
-  netcdf-fortran:
-    max_pin: x.x
-  nettle:
-    max_pin: x.x
-  nlopt:
-    max_pin: x.x.x
-  nss:
-    max_pin: x
-  nspr:
-    max_pin: x
   occt:
-    max_pin: x.x
-  openturns:
-    max_pin: x.x
-  openjpeg:
-    max_pin: x.x
-  pango:
     max_pin: x.x
   poppler:
     max_pin: x.x
-  qt:
-    max_pin: x.x
-  qtkeychain:
-    max_pin: x.x
-  readline:
-    max_pin: x
   r-base:
     max_pin: x.x
     min_pin: x.x
-  sox:
-    max_pin: x.x.x
-  sqlite:
-    max_pin: x
-  tk:
-    max_pin: x.x
-  tiledb:
-    max_pin: x.x
   vlfeat:
     max_pin: x.x.x
-  vtk:
-    max_pin: x.x.x
-  xz:
-    max_pin: x.x
-  zeromq:
-    max_pin: x.x  # [not win]
-    max_pin: x.x.x  # [win]
-  zlib:
-    max_pin: x.x
 
 # Pinning packages
 
 # blas
 libblas:
-  - 3.8 *netlib  # [not (osx and arm64)]
-  - 3.9 *netlib  # [osx and arm64]
+  - 3.9 *netlib
 libcblas:
-  - 3.8 *netlib  # [not (osx and arm64)]
-  - 3.9 *netlib  # [osx and arm64]
+  - 3.9 *netlib
 liblapack:
-  - 3.8 *netlib  # [not (osx and arm64)]
-  - 3.9 *netlib  # [osx and arm64]
+  - 3.9 *netlib
 liblapacke:
-  - 3.8 *netlib  # [not (osx and arm64)]
-  - 3.9 *netlib  # [osx and arm64]
+  - 3.9 *netlib
 blas_impl:
   - openblas
   - mkl          # [x86 or x86_64]
   - blis         # [x86 or x86_64]
 
+# this output was dropped as of libabseil 20230125
 abseil_cpp:
-  - '20210324.2'
+  - '20220623.0'
 alsa_lib:
-  - 1.2.3
+  - 1.2.8
 antic:
   - 0.2
+aom:
+  - 3.5
 arb:
-  - '2.22'
+  - '2.23'
 arpack:
   - 3.7
+# keep in sync with libarrow
 arrow_cpp:
-  - 7.0.0
-  - 6.0.1
-  - 5.0.0
-  - 4.0.1
+  - 12
+  - 11.0.0
+  - 10.0.1
+  - 9.0.0
 assimp:
-  - 5.2
+  - 5.2.5
 attr:
   - 2.5
 aws_c_auth:
-  - 0.6.11
+  - 0.7.0
 aws_c_cal:
-  - 0.5.17
+  - 0.6.0
 aws_c_common:
-  - 0.6.20
+  - 0.8.23
+# coupled to aws_c_common version bump, see
+# https://github.com/conda-forge/aws-c-http-feedstock/pull/109
 aws_c_event_stream:
-  - 0.2.7
+  - 0.3.1
 aws_c_http:
-  - 0.6.14
-aws_c_io:
-  - 0.10.22
-aws_c_mqtt:
   - 0.7.10
+# the builds got coupled because 0.2.4 landed before the this migrator finished
+aws_c_io:
+  - 0.13.28
+# the builds got coupled because 0.2.4 landed before the io migrator
+aws_c_mqtt:
+  - 0.8.14
 aws_c_s3:
-  - 0.1.38
+  - 0.3.13
 aws_c_sdkutils:
-  - 0.1.2
+  - 0.1.11
 aws_checksums:
-  - 0.1.12
+  - 0.1.16
 aws_crt_cpp:
-  - 0.17.28
+  - 0.20.3
 aws_sdk_cpp:
-  - 1.9.160
+  - 1.10.57
 boost:
-  - 1.74.0
+  - 1.78.0
 boost_cpp:
-  - 1.74.0
+  - 1.78.0
 bzip2:
   - 1
+c_ares:
+  - 1
 cairo:
-  - 1.16
+  - 1
 capnproto:
-  - 0.9.1
+  - 0.10.2
 ccr:
   - 1.3
 cfitsio:
-  - 4.0.0
+  - 4.1.0
 coin_or_cbc:
   - 2.10
 coincbc:
@@ -408,29 +310,40 @@ coin_or_osi:
   - 0.108
 coin_or_utils:
   - 2.11
+console_bridge:
+  - 1.0
 cutensor:
   - 1
 curl:
-  - 7
+  - 8
+dav1d:
+  - 1.2.1
 davix:
   - '0.8'
 dbus:
   - 1
+dcap:
+  - 2.47
+eclib:
+  - '20230424'
+elfutils:
+  - 0.189
 exiv2:
   - 0.27
 expat:
   - 2
 ffmpeg:
-  - '4.3'  # [win]
-  - '4.4'  # [unix]
+  - '6'
 fftw:
   - 3
 flann:
   - 1.9.1
+flatbuffers:
+  - 23.5.26
 fmt:
-  - '8'
+  - '9'
 fontconfig:
-  - 2.13
+  - 2
 freetype:
   - 2
 gct:
@@ -440,23 +353,25 @@ gf2x:
 gdk_pixbuf:
   - 2
 gnuradio_core:
-  - 3.10.1
+  - 3.10.6
+gnutls:
+  - 3.7
 gsl:
   - 2.7
 gsoap:
-  - 2.8.119
+  - 2.8.123
 gstreamer:
-  - '1.20'
+  - '1.22'
 gst_plugins_base:
-  - '1.20'
+  - '1.22'
 gdal:
-  - '3.4'
+  - '3.6'
 geos:
-  - 3.10.2
+  - 3.11.2
 geotiff:
   - 1.7.1
 gfal2:
-  - '2.20'
+  - '2.21'
 gflags:
   - 2.2
 giflib:
@@ -468,85 +383,114 @@ glib:
 glog:
   - '0.6'
 glpk:
-  - 4.65
+  - '5.0'
 gmp:
   - 6
+# keep google_cloud_cpp in sync with libgoogle_cloud
 google_cloud_cpp:
-  - '1.36'
+  - '2.12'
 google_cloud_cpp_common:
   - 0.25.0
 googleapis_cpp:
   - '0.10'
 graphviz:
-  - 2.47
+  - '8'
+# this has been renamed to libgrpc as of 1.49; dropped as of 1.52.
+# IOW, this version is unavailable; makes the renaming more obvious
 grpc_cpp:
-  - '1.43'
+  - '1.52'
 harfbuzz:
-  - '4'
+  - '6'
 hdf4:
   - 4.2.15
 hdf5:
-  - 1.10.6
+  - 1.12.2
 icu:
-  - '69'
+  - '70'
 imath:
-  - '3.1'
+  - 3.1.9
 ipopt:
-  - 3.14
+  - 3.14.12
 isl:
-  - '0.22'
+  - '0.25'
 jasper:
-  - '2'
+  - 4
 jpeg:
   - 9
+lcms:
+  - 2
+lerc:
+  - '4'
 libjpeg_turbo:
   - 2
+libev:
+  - 4.33
 json_c:
-  - 0.15
+  - '0.16'
 jsoncpp:
   - 1.9.5
 kealib:
-  - 1.4
+  - '1.5'
 krb5:
   - '1.19'
+libabseil:
+  - '20230125'
+libabseil_static:
+  - '20220623.0'
+libaec:
+  - '1'
 libarchive:
-  - 3.5
+  - '3.6'
+# keep in sync with arrow_cpp (libarrow exists only from 10.x,
+# but make sure we have same length for zip as arrow_cpp)
+libarrow:
+  - 12
+  - 11.0.0
+  - 10.0.1
+  - 9.0.0
 libavif:
-  - 0.10.1
+  - 0.11.1
 libblitz:
   - 1.0.2
 libcint:
-  - '5.1'
+  - '5.2'
 libcurl:
-  - 7
+  - 8
 libcrc32c:
   - 1.1
 libdap4:
   - 3.20.6
 libdeflate:
-  - '1.10'
+  - '1.18'
 libeantic:
   - 1
 libevent:
-  - 2.1.10
+  - 2.1.12
 libexactreal:
-  - 2
+  - '3'
 libffi:
-  - '3.3'
+  - '3.4'
 libflatsurf:
   - 3
 libflint:
-  - '2.8'
+  - '2.9'
 libgdal:
-  - '3.4'
+  - '3.6'
 libgit2:
-  - '1.4'
+  - '1.6'
+# Keep in sync with google_cloud_cpp
+libgoogle_cloud:
+  - '2.12'
+libgrpc:
+  - '1.52'
 libhugetlbfs:
   - 2
 libhwy:
-  - 0.15
+  - '1.0'
 libiconv:
-  - 1.16
+  - 1
+libidn2:
+  - 2
 libintervalxt:
   - 3
 libkml:
@@ -560,29 +504,44 @@ libmicrohttpd:
 libnetcdf:
   - 4.8.1
 libopencv:
-  - 4.5.5
+  - 4.7.0
+libosqp:
+  - 0.6.3
 libpcap:
   - '1.10'
 libpng:
   - 1.6
 libprotobuf:
-  - '3.19'
+  - '3.21'
+libpq:
+  - 15
+libraw:
+  - '0.21'
 librdkafka:
-  - '1.7'
+  - '1.9'
 librsvg:
   - 2
 libsecret:
   - 0.18
+libsentencepiece:
+  - '0.1.99'
+libsndfile:
+  - '1.2'
 libspatialindex:
   - 1.9.3
+libssh:
+  - 0.10
 libssh2:
   - 1
 libsvm:
-  - 3.21
+  - '325'
+# keep libsqlite in sync with sqlite
+libsqlite:
+  - 3
 libthrift:
-  - 0.16.0
+  - 0.18.1
 libtiff:
-  - 4
+  - 4.4
 libunwind:
   - '1.6'
 libv8:
@@ -594,7 +553,7 @@ libwebp:
 libwebp_base:
   - 1
 libxml2:
-  - 2.9
+  - 2.10
 libxsmm:
   - 1
 libuuid:
@@ -604,25 +563,27 @@ libzip:
 log4cxx:
   - 0.11.0
 lz4_c:
-  - 1.9.3
+  - '1.9.3'
 lzo:
   - 2
 metis:
   - 5.1
 mimalloc:
-  - 2.0.6
+  - 2.1.1
 mkl:
   - 2022
 mkl_devel:
   - 2022
+mpg123:
+  - '1.31'
 mpich:
   - 4
 mpfr:
   - 4
 mumps_mpi:
-  - 5.2
+  - 5.2.1
 mumps_seq:
-  - 5.2
+  - 5.2.1
 nccl:
   - 2
 ncurses:
@@ -632,11 +593,10 @@ netcdf_cxx4:
 netcdf_fortran:
   - 4.5
 nettle:
-  - '3.7'
+  - '3.8'
 nodejs:
-  - '17'
+  - '18'
   - '16'
-  - '14'  # [not (osx and arm64)]
 nss:
   - 3
 nspr:
@@ -648,99 +608,123 @@ ntl:
 # we build for the oldest version possible of numpy for forward compatibility
 numpy:
   # part of a zip_keys: python, python_impl, numpy
-  - 1.19   # [not (osx and arm64)]
-  - 1.19
-  - 1.19
-  - 1.19
-  - 1.19
+  - 1.21
+  - 1.21
+  - 1.21
 occt:
-  - '7.5'
+  - '7.7'
 openblas:
   - 0.3.*
 openexr:
   - '3.1'
+openh264:
+  - '2.3.1'
 openjpeg:
-  - '2.4'
+  - '2'
 openmpi:
   - 4
 openssl:
-  - 1.1.1
+  - '3'
 openturns:
-  - '1.18'
+  - '1.20'
 orc:
-  - 1.7.3
+  - 1.8.4
 pango:
-  - '1.48'
+  - 1.50
 pari:
-  - 2.13.* *_pthread
+  - 2.15.* *_pthread
+pcl:
+  - 1.13.0
 perl:
   - 5.32.1
 petsc:
-  - '3.16'
+  - '3.18'
 petsc4py:
-  - '3.16'
+  - '3.18'
 slepc:
-  - '3.16'
+  - '3.18'
 slepc4py:
-  - '3.16'
+  - '3.18'
 svt_av1:
-  - '1.1.0'
+  - 1.6.0
+p11_kit:
+  - '0.24'
 pcre:
   - '8'
 pcre2:
-  - '10.37'
+  - '10.40'
 pixman:
   - 0
 poco:
-  - 1.11.1
+  - 1.12.4
 poppler:
-  - '22.01'
+  - '22.12'
+postgresql:
+  - 15
+postgresql_plpython:
+  - 15
 proj:
-  - 9.0.0
+  - 9.2.0
 pulseaudio:
-  - 14.0
+  - '16.1'
 pybind11_abi:
   - 4
 python:
   # part of a zip_keys: python, python_impl, numpy
-  - 3.7.* *_cpython    # [not (osx and arm64)]
   - 3.8.* *_cpython
   - 3.9.* *_cpython
   - 3.10.* *_cpython
-  - 3.11.* *_cpython
 python_impl:
   # part of a zip_keys: python, python_impl, numpy
-  - cpython   # [not (osx and arm64)]
-  - cpython
   - cpython
   - cpython
   - cpython
 pytorch:
-  - '1.11'
+  - '2.0'
+pyqt:
+  - 5.15
+pyqtwebengine:
+  - 5.15
+pyqtchart:
+  - 5.15
 qt:
-  - 5.12
+  - 5.15
+qt_main:
+  - 5.15
+qt6_main:
+  - '6.5'
 qtkeychain:
-  - '0.12'
+  - '0.14'
 re2:
-  - 2022.02.01
+  - 2023.03.02
 readline:
   - "8"
 rocksdb:
   - "6.10"
 root_base:
-  - 6.26.2
+  - 6.26.10
 ruby:
   - 2.5
   - 2.6
 r_base:
-  - 4.0
-  - 4.1
+  - 4.1   # [win]
+  - 4.2   # [not win]
 scotch:
   - 6.0.9
 ptscotch:
   - 6.0.9
 s2n:
-  - 1.3.11
+  - 1.3.46
+sdl2:
+  - '2'
+sdl2_image:
+  - '2'
+sdl2_mixer:
+  - '2'
+sdl2_net:
+  - '2'
+sdl2_ttf:
+  - '2'
 singular:
   - 4.2.1.p3
 snappy:
@@ -750,9 +734,12 @@ soapysdr:
 sox:
   - 14.4.2
 spdlog:
-  - '1.10'
+  - '1.11'
+# keep sqlite in sync with libsqlite
 sqlite:
   - 3
+srm_ifce:
+  - 1.24.6
 starlink_ast:
   - '9.2.7'
 suitesparse:
@@ -760,35 +747,37 @@ suitesparse:
 superlu_dist:
   - 7.1.1
 tbb:
-  - 2020
+  - '2021'
 tbb_devel:
-  - 2020
+  - '2021'
 thrift_cpp:
-  - 0.16.0
+  - 0.18.1
 tinyxml2:
   - 9
 tk:
   - 8.6                # [not ppc64le]
 tiledb:
-  - '2.8'
+  - '2.13'
 ucx:
-  - 1.12.1
+  - 1.14.0
 uhd:
-  - 4.2.0
+  - 4.4.0
+urdfdom:
+  - 3.1
 vc:                    # [win]
   - 14                 # [win]
 vlfeat:
-  - 0.9.20
+  - 0.9.21
 volk:
-  - '2.5'
+  - '3.0'
 vtk:
-  - 9.0.1
+  - 9.2.5
 wcslib:
-  - '7.7'
+  - '7'
 wxwidgets:
-  - '3.1'
+  - '3.2'
 x264:
-  - '1!161.*'
+  - '1!164.*'
 x265:
   - '3.5'
 xerces_c:
@@ -796,9 +785,11 @@ xerces_c:
 xrootd:
   - '5'
 xz:
-  - 5.2
+  - 5
 zeromq:
   - 4.3.4
+zfp:
+  - 1.0
 zlib:
   - 1.2
 zlib_ng:

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault2
+  version: {{ version }}.memfault3
 
 source:
   - git_url: https://github.com/espressif/binutils-gdb.git


### PR DESCRIPTION
Incompatibility in the libiconv dep with some newer packages.

Refresh the file via:

```bash
❯ curl -sSL https://github.com/conda-forge/conda-forge-pinning-feedstock/raw/main/recipe/conda_build_config.yaml > gdb-xtensa-esp32-elf/conda_build_config.yaml
```

After rebuild, the package deps are now:

```json
    "libiconv 1.*",
    "libiconv >=1.17,<2.0a0",
```
