### PR TITLE
Add go-shfmt for ARM64 support

### DIFF
--- a/go-shfmt/build.sh
+++ b/go-shfmt/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+CGO_ENABLED=0 go build -trimpath -ldflags="-w -s -X=main.version=v${PKG_VERSION}" -o "${PREFIX}/bin/shfmt" ./cmd/shfmt

--- a/go-shfmt/meta.yaml
+++ b/go-shfmt/meta.yaml
@@ -1,3 +1,8 @@
+# conda package: 
+# https://anaconda.org/conda-forge/go-shfmt  
+# https://github.com/conda-forge/go-shfmt-feedstock
+# we have our own recipe because that does not currently (2023-08) have macOS ARM64 support
+
 {% set version = "3.7.0" %}
 
 package:

--- a/go-shfmt/meta.yaml
+++ b/go-shfmt/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "3.7.0" %}
+
+package:
+  name: go-shfmt
+  version: {{ version }}.memfault0
+
+source:
+  - url: https://github.com/mvdan/sh/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 89eafc8790df93305dfa42233e262fb25e1c96726a3db420a7555abadf3111ed
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - go-nocgo=1.20.7
+
+test:
+  commands:
+    - shfmt --version
+
+about:
+  home: https://github.com/mvdan/sh
+  license_family: BSD
+  license: BSD-3-Clause
+  summary: A shell parser, formatter, and interpreter with bash support; includes shfmt
+  doc_url: https://github.com/mvdan/sh
+  dev_url: https://github.com/mvdan/sh


### PR DESCRIPTION
https://anaconda.org/conda-forge/go-shfmt exists but doesn’t have an osx-arm64 build