### PR TITLE
Fix gdb-xtensa-esp32-elf build on macOS ARM64

### DIFF
--- a/gdb-xtensa-esp32-elf/build.sh
+++ b/gdb-xtensa-esp32-elf/build.sh
@@ -38,7 +38,11 @@ mkdir -p "${GDB_DIST}"/lib
 pushd xtensaconfig
 make clean
 # AR="$TARGET_HOST-ar" CC="$TARGET_HOST-gcc"
-TARGET_ESP_ARCH=${ESP_CHIP_ARCHITECTURE} DESTDIR="${GDB_DIST}" PLATFORM=$PLATFORM make install
+if [ -z "$MACOSX_DEPLOYMENT_TARGET" ]; then
+  TARGET_ESP_ARCH=${ESP_CHIP_ARCHITECTURE} DESTDIR="${GDB_DIST}" PLATFORM=$PLATFORM make install
+else
+  TARGET_ESP_ARCH=${ESP_CHIP_ARCHITECTURE} DESTDIR="${GDB_DIST}" PLATFORM=$PLATFORM make install CFLAGS="-Wl,-L,$(xcode-select -p)/SDKs/MacOSX.sdk/usr/lib -Wl,-lSystem"
+fi
 popd
 # Install xtensa-config libs
 mkdir -p "$TARGET_PREFIX"/lib

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault1
+  version: {{ version }}.memfault2
 
 source:
   - git_url: https://github.com/espressif/binutils-gdb.git

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -39,11 +39,11 @@ requirements:
     - python {{ python }}
     - ncurses {{ ncurses }}
     - xz {{ xz }}
-    - zlib {{ zlib }}
+    - zlib {{ zlib }} # [not osx]
     - libiconv {{ libiconv }}
     - mpfr {{ mpfr }}
-    - gmp {{ gmp }}
-    - expat {{ expat }}
+    - gmp {{ gmp }} # [not osx]
+    - expat {{ expat }} # [not osx]
 
 test:
   commands:


### PR DESCRIPTION
Supersedes #46

I bumped it to `memfault2` since there's already a `memfault2` on Anaconda - should be fine since there are no Mac builds there yet and I only changed Mac specific logic.

https://anaconda.org/Memfault/xtensa-esp32-elf-gdb/files?version=12.1_20221002.memfault2