### PR TITLE
Compress clickhouse with upx

### DIFF
--- a/clickhouse/build.sh
+++ b/clickhouse/build.sh
@@ -9,6 +9,11 @@ ARCH=$(uname -m)
 # copy the binary into the installation target
 if [ "${OS}" = "Linux" ]; then
   cp $SRC_DIR/usr/bin/clickhouse $TARGET_BIN
+
+  # the clickhouse binary is like 500MB on linux. let's pack it.
+  wget https://github.com/upx/upx/releases/download/v4.1.0/upx-4.1.0-amd64_linux.tar.xz
+  tar -xf upx-4.1.0-amd64_linux.tar.xz
+  ./upx-4.1.0-amd64_linux/upx $TARGET_BIN
 elif [ "${OS}" = "Darwin" ]; then
   if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]; then
     ARCH_SUFFIX=""

--- a/clickhouse/meta.yaml
+++ b/clickhouse/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}.memfault0
+  version: {{ version }}.memfault1
 
 source:
   - url: https://github.com/ClickHouse/ClickHouse/releases/download/v{{ version }}-lts/clickhouse-macos # [osx and x86_64]


### PR DESCRIPTION
Only for linux. Normally the clickhouse binary is ~496MB.

This doesn't reduce the conda package size substantially,
unsurprisingly.
