### PR TITLE
Prefer existing VOLTA_HOME if already set

### DIFF
--- a/volta/activate.sh
+++ b/volta/activate.sh
@@ -1,7 +1,9 @@
-# if VOLTA_HOME is set, save it to VOLTA_HOME_BACKUP
+# if VOLTA_HOME is set, don't override it- save it so the deactivate script
+# knows to not unset it
 if [ -n "$VOLTA_HOME" ]; then
-  export VOLTA_HOME_BACKUP="$VOLTA_HOME"
+  export VOLTA_HOME_PREFERRED="$VOLTA_HOME"
+else
+  # set the volta directory to reside inside the conda environment
+  export VOLTA_HOME="$CONDA_PREFIX"/.volta
+  export PATH="$VOLTA_HOME/bin:$PATH"
 fi
-
-# set the volta directory to reside inside the conda environment
-export VOLTA_HOME="$CONDA_PREFIX"/.volta

--- a/volta/deactivate.sh
+++ b/volta/deactivate.sh
@@ -1,6 +1,15 @@
-# if VOLTA_HOME_BACKUP is set, restore it to VOLTA_HOME
-unset VOLTA_HOME
-if [ -n "$VOLTA_HOME_BACKUP" ]; then
-  export VOLTA_HOME="$VOLTA_HOME_BACKUP"
-  unset VOLTA_HOME_BACKUP
+# if VOLTA_HOME_PREFERRED is set, don't unset VOLTA_HOME; the user activated the
+# conda environment with VOLTA_HOME already set, and we don't want to mess with
+# it
+if [ -n "$VOLTA_HOME_PREFERRED" ]; then
+  unset VOLTA_HOME_PREFERRED
+else
+  # otherwise, clean up after ourselves
+  directory_to_remove=$VOLTA_HOME/bin
+  # from https://unix.stackexchange.com/a/108933
+  PATH=:$PATH:
+  PATH=${PATH//:$directory_to_remove:/:}
+  PATH=${PATH#:}
+  PATH=${PATH%:}
+  unset VOLTA_HOME
 fi

--- a/volta/meta.yaml
+++ b/volta/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault0
+  version: {{ version }}.memfault1
 
 source:
   # bash for getting the sigs:


### PR DESCRIPTION
This enables using an arm64 volta install (i.e. no rosetta for node)
with an x86 conda environment on macos-arm64.
