### PR TITLE
fix(volta): allow activate.sh to work in strict mode

### DIFF
--- a/volta/activate.sh
+++ b/volta/activate.sh
@@ -1,6 +1,6 @@
 # if VOLTA_HOME is set, don't override it- save it so the deactivate script
 # knows to not unset it
-if [ -n "$VOLTA_HOME" ]; then
+if [ -n "${VOLTA_HOME-}" ]; then
   export VOLTA_HOME_PREFERRED="$VOLTA_HOME"
 else
   # set the volta directory to reside inside the conda environment

--- a/volta/meta.yaml
+++ b/volta/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault1
+  version: {{ version }}.memfault2
 
 source:
   # bash for getting the sigs:


### PR DESCRIPTION
  ### Summary

If the script is sourced when run in strict mode (`-u`) (disallowing unbound variables, the activate.sh script would fail because `VOLTA_HOME` was unbound. This PR adds a fallback to avoid this error.

  ### Test plan

Add `set -u` at the top of the script and run it. Observe it no longer fails.