### PR TITLE
Use conda-forge feedstock for elfutils

### DIFF
--- a/elfutils/conda_build_config.yaml
+++ b/elfutils/conda_build_config.yaml
@@ -1,0 +1,798 @@
+c_compiler:
+  - gcc                        # [linux]
+  - clang                      # [osx]
+  - vs2019                     # [win and x86_64]
+  - vs2022                     # [win and arm64]
+c_compiler_version:            # [unix]
+  - 12                         # [linux]
+  - 16                         # [osx]
+  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux]
+cxx_compiler:
+  - gxx                        # [linux]
+  - clangxx                    # [osx]
+  - vs2019                     # [win and x86_64]
+  - vs2022                     # [win and arm64]
+cxx_compiler_version:          # [unix]
+  - 12                         # [linux]
+  - 16                         # [osx]
+  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux]
+llvm_openmp:                   # [osx]
+  - 16                         # [osx]
+fortran_compiler:              # [unix or win64]
+  - gfortran                   # [linux64 or (osx and x86_64)]
+  - gfortran                   # [aarch64 or ppc64le or armv7l or s390x]
+  - flang                      # [win64]
+fortran_compiler_version:      # [unix or win64]
+  - 12                         # [linux]
+  - 12                         # [osx]
+  - 5                          # [win64]
+  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux]
+m2w64_c_compiler:              # [win]
+  - m2w64-toolchain            # [win]
+m2w64_cxx_compiler:            # [win]
+  - m2w64-toolchain            # [win]
+m2w64_fortran_compiler:        # [win]
+  - m2w64-toolchain            # [win]
+
+cuda_compiler:
+  - None
+  - nvcc                       # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cuda_compiler_version:
+  - None
+  - 11.2                       # [(linux or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+cuda_compiler_version_min:
+  - None                       # [osx]
+  - 11.2                       # [linux or win64]
+
+arm_variant_type:              # [aarch64]
+  - sbsa                       # [aarch64]
+
+_libgcc_mutex:
+  - 0.1 conda_forge
+#
+# Go Compiler Options
+#
+
+# The basic go-compiler with CGO disabled,
+# It generates fat binaries without libc dependencies
+# The activation scripts will set your CC,CXX and related flags
+# to invalid values.
+go_compiler:
+  - go-nocgo
+# The go compiler build with CGO enabled.
+# It can generate fat binaries that depend on conda's libc.
+# You should use this compiler if the underlying
+# program needs to link against other C libraries, in which
+# case make sure to add  'c,cpp,fortran_compiler' for unix
+# and the m2w64 equivalent for windows.
+cgo_compiler:
+  - go-cgo
+# The following are helpful variables to simplify go meta.yaml files.
+target_goos:
+  - linux                      # [linux]
+  - darwin                     # [osx]
+  - windows                    # [win]
+target_goarch:
+  - amd64                      # [x86_64]
+  - arm64                      # [arm64 or aarch64]
+  - ppc64le                    # [ppc64le]
+target_goexe:
+  -                            # [unix]
+  - .exe                       # [win]
+target_gobin:
+  - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]
+
+# Rust Compiler Options
+rust_compiler:
+  - rust
+
+macos_machine:                 # [osx]
+  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]
+MACOSX_DEPLOYMENT_TARGET:      # [osx]
+  - 11.0                       # [osx and arm64]
+  - 10.9                       # [osx and x86_64]
+VERBOSE_AT:
+  - V=1
+VERBOSE_CM:
+  - VERBOSE=1
+
+# dual build configuration
+channel_sources:
+  - conda-forge                                 # [not s390x]
+  - https://conda-web.anaconda.org/conda-forge  # [s390x]
+
+channel_targets:
+  - conda-forge main
+
+cdt_name:  # [linux]
+  - cos6   # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos6"]
+  - cos7   # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos7"]
+  - cos7   # [linux and aarch64]
+  - cos7   # [linux and ppc64le]
+  - cos7   # [linux and armv7l]
+  - cos7   # [linux and s390x]
+
+  - cos7   # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+docker_image:                                   # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
+  # Native builds
+  - quay.io/condaforge/linux-anvil-cos7-x86_64  # [os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - quay.io/condaforge/linux-anvil-aarch64      # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+  - quay.io/condaforge/linux-anvil-ppc64le      # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+  - quay.io/condaforge/linux-anvil-armv7l       # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l"]
+
+  # CUDA 11.2
+  - quay.io/condaforge/linux-anvil-cuda:11.2              # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  # CUDA 11.2 arch: native compilation (build == target)
+  - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2      # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
+  - quay.io/condaforge/linux-anvil-aarch64-cuda:11.2      # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
+  # CUDA 11.2 arch: cross-compilation (build != target)
+  - quay.io/condaforge/linux-anvil-cuda:11.2              # [ppc64le and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - quay.io/condaforge/linux-anvil-cuda:11.2              # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+
+zip_keys:
+  -                             # [unix]
+    - c_compiler_version        # [unix]
+    - cxx_compiler_version      # [unix]
+    - fortran_compiler_version  # [unix]
+    - cuda_compiler             # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - cuda_compiler_version     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - cdt_name                  # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - docker_image              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
+  -                             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - cuda_compiler             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    - cuda_compiler_version     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  -
+    - python
+    - numpy
+    - python_impl
+  # transition until arrow_cpp can be dropped for arrow 13.x
+  -
+    - arrow_cpp
+    - libarrow
+  # as of 4.23.x, libprotobuf requires patch-level run-exports;
+  # we couple it with grpc (which very roughly releases in sync)
+  # to reduce the migration pain for these two libs a bit.
+  -
+    - libgrpc
+    - libprotobuf
+
+
+# aarch64 specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: aarch64                       # [aarch64]
+BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
+
+# armv7l specifics because conda-build sets many things to centos 6
+# this can probably be removed when conda-build gets updated defaults
+# for aarch64
+cdt_arch: armv7l                          # [armv7l]
+BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
+
+pin_run_as_build:
+  # boost is special, see https://github.com/conda-forge/boost-cpp-feedstock/pull/82
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  # TODO: add run_exports to the following feedstocks
+  flann:
+    max_pin: x.x.x
+  graphviz:
+    max_pin: x
+  libsvm:
+    max_pin: x
+  netcdf-cxx4:
+    max_pin: x.x
+  occt:
+    max_pin: x.x
+  poppler:
+    max_pin: x.x
+  r-base:
+    max_pin: x.x
+    min_pin: x.x
+  vlfeat:
+    max_pin: x.x.x
+
+# Pinning packages
+
+# blas
+libblas:
+  - 3.9 *netlib
+libcblas:
+  - 3.9 *netlib
+liblapack:
+  - 3.9 *netlib
+liblapacke:
+  - 3.9 *netlib
+blas_impl:
+  - openblas
+  - mkl          # [x86 or x86_64]
+  - blis         # [x86 or x86_64]
+
+# this output was dropped as of libabseil 20230125
+abseil_cpp:
+  - '20220623.0'
+alsa_lib:
+  - 1.2.9
+antic:
+  - 0.2
+aom:
+  - '3.6'
+arb:
+  - '2.23'
+arpack:
+  - 3.7
+# keep in sync with libarrow
+arrow_cpp:
+  - 13
+  - 12
+  - 11.0.0
+  - 10.0.1
+assimp:
+  - 5.2.5
+attr:
+  - 2.5
+aws_c_auth:
+  - 0.7.4
+aws_c_cal:
+  - 0.6.2
+aws_c_common:
+  - 0.9.3
+aws_c_compression:
+  - 0.2.17
+# coupled to aws_c_common version bump, see
+# https://github.com/conda-forge/aws-c-http-feedstock/pull/109
+aws_c_event_stream:
+  - 0.3.2
+aws_c_http:
+  - 0.7.13
+# the builds got coupled because 0.2.4 landed before the this migrator finished
+aws_c_io:
+  - 0.13.32
+# the builds got coupled because 0.2.4 landed before the io migrator
+aws_c_mqtt:
+  - 0.9.6
+aws_c_s3:
+  - 0.3.17
+aws_c_sdkutils:
+  - 0.1.12
+aws_checksums:
+  - 0.1.17
+aws_crt_cpp:
+  - 0.24.2
+aws_sdk_cpp:
+  - 1.11.156
+boost:
+  - 1.78.0
+boost_cpp:
+  - 1.78.0
+bzip2:
+  - 1
+c_ares:
+  - 1
+cairo:
+  - 1
+capnproto:
+  - 0.10.2
+ccr:
+  - 1.3
+cfitsio:
+  - 4.2.0
+coin_or_cbc:
+  - 2.10
+coincbc:
+  - 2.10
+coin_or_cgl:
+  - 0.60
+coin_or_clp:
+  - 1.17
+coin_or_osi:
+  - 0.108
+coin_or_utils:
+  - 2.11
+console_bridge:
+  - 1.0
+cudnn:
+  - 8
+cutensor:
+  - 1
+curl:
+  - 8
+dav1d:
+  - 1.2.1
+davix:
+  - '0.8'
+dbus:
+  - 1
+dcap:
+  - 2.47
+eclib:
+  - '20230424'
+elfutils:
+  - 0.189
+exiv2:
+  - 0.27
+expat:
+  - 2
+ffmpeg:
+  - '6'
+fftw:
+  - 3
+flann:
+  - 1.9.1
+flatbuffers:
+  - 23.5.26
+fmt:
+  - '9'
+fontconfig:
+  - 2
+freetype:
+  - 2
+gct:
+  - 6.2.1629922860
+gf2x:
+  - '1.3'
+gdk_pixbuf:
+  - 2
+gnuradio_core:
+  - 3.10.7
+gnutls:
+  - 3.7
+gsl:
+  - 2.7
+gsoap:
+  - 2.8.123
+gstreamer:
+  - '1.22'
+gst_plugins_base:
+  - '1.22'
+gdal:
+  - '3.7'
+geos:
+  - 3.12.0
+geotiff:
+  - 1.7.1
+gfal2:
+  - '2.21'
+gflags:
+  - 2.2
+giflib:
+  - 5.2
+glew:
+  - 2.1
+glib:
+  - '2'
+glog:
+  - '0.6'
+glpk:
+  - '5.0'
+gmp:
+  - 6
+# keep google_cloud_cpp in sync with libgoogle_cloud
+google_cloud_cpp:
+  - '2.12'
+google_cloud_cpp_common:
+  - 0.25.0
+googleapis_cpp:
+  - '0.10'
+graphviz:
+  - '8'
+# this has been renamed to libgrpc as of 1.49; dropped as of 1.52.
+# IOW, this version is unavailable; makes the renaming more obvious
+grpc_cpp:
+  - '1.52'
+harfbuzz:
+  - '8'
+hdf4:
+  - 4.2.15
+hdf5:
+  - 1.14.2
+icu:
+  - '72'
+imath:
+  - 3.1.9
+ipopt:
+  - 3.14.12
+isl:
+  - '0.25'
+jasper:
+  - 4
+jpeg:
+  - 9
+lcms:
+  - 2
+lerc:
+  - '4'
+libjpeg_turbo:
+  - 2.1.5
+libev:
+  - 4.33
+json_c:
+  - '0.17'
+jsoncpp:
+  - 1.9.5
+kealib:
+  - '1.5'
+krb5:
+  - '1.20'
+libabseil:
+  - '20230802'
+libabseil_static:
+  - '20220623.0'
+libaec:
+  - '1'
+libarchive:
+  - '3.7'
+# keep in sync with arrow_cpp (libarrow exists only from 10.x,
+# but make sure we have same length for zip as arrow_cpp)
+libarrow:
+  - 13
+  - 12
+  - 11.0.0
+  - 10.0.1
+libavif:
+  - '1.0.1'
+libblitz:
+  - 1.0.2
+libcint:
+  - '5.5'
+libcurl:
+  - 8
+libcrc32c:
+  - 1.1
+libdap4:
+  - 3.20.6
+libdeflate:
+  - '1.19'
+libeantic:
+  - 1
+libevent:
+  - 2.1.12
+libexactreal:
+  - '3'
+libffi:
+  - '3.4'
+libflatsurf:
+  - 3
+libflint:
+  - '2.9'
+libgdal:
+  - '3.7'
+libgit2:
+  - '1.7'
+# Keep in sync with google_cloud_cpp
+libgoogle_cloud:
+  - '2.12'
+libgrpc:
+  - '1.57'
+libhugetlbfs:
+  - 2
+libhwy:
+  - '1.0'
+libiconv:
+  - 1
+libidn2:
+  - 2
+libintervalxt:
+  - 3
+libkml:
+  - 1.3
+libiio:
+  - 0
+libmatio:
+  - 1.5.23
+libmicrohttpd:
+  - 0.9
+libnetcdf:
+  - 4.9.2
+libopencv:
+  - 4.8.0
+libosqp:
+  - 0.6.3
+libpcap:
+  - '1.10'
+libpng:
+  - 1.6
+libprotobuf:
+  - 4.23.4
+libpq:
+  - 15
+libraw:
+  - '0.21'
+librdkafka:
+  - '2.2'
+librsvg:
+  - 2
+libsecret:
+  - 0.18
+libsentencepiece:
+  - '0.1.99'
+libsndfile:
+  - '1.2'
+libspatialindex:
+  - 1.9.3
+libssh:
+  - 0.10
+libssh2:
+  - 1
+libsvm:
+  - '332'
+# keep libsqlite in sync with sqlite
+libsqlite:
+  - 3
+libthrift:
+  - 0.18.1
+libtiff:
+  - '4.5'
+libunwind:
+  - '1.6'
+libv8:
+  - 8.9.83
+libvips:
+  - 8
+libwebp:
+  - 1
+libwebp_base:
+  - 1
+libxml2:
+  - '2.11'
+libxsmm:
+  - 1
+libuuid:
+  - 2
+libzip:
+  - 1
+lmdb:
+  - 0.9.29
+log4cxx:
+  - 0.11.0
+lz4_c:
+  - '1.9.3'
+lzo:
+  - 2
+metis:
+  - 5.1
+mimalloc:
+  - 2.1.2
+mkl:
+  - 2022
+mkl_devel:
+  - 2022
+mpg123:
+  - '1.32'
+mpich:
+  - 4
+mpfr:
+  - 4
+msgpack_c:
+  - 6
+msgpack_cxx:
+  - 6
+mumps_mpi:
+  - 5.2.1
+mumps_seq:
+  - 5.2.1
+nccl:
+  - 2
+ncurses:
+  - 6
+netcdf_cxx4:
+  - 4.3
+netcdf_fortran:
+  - '4.6'
+nettle:
+  - '3.8'
+nodejs:
+  - '18'
+  - '16'
+nss:
+  - 3
+nspr:
+  - 4
+nlopt:
+  - '2.7'
+ntl:
+  - '11.4.3'
+# we build for the oldest version possible of numpy for forward compatibility
+# we roughly follow NEP29 in choosing the oldest version
+numpy:
+  # part of a zip_keys: python, python_impl, numpy
+  - 1.22
+  - 1.22
+  - 1.22
+  - 1.23
+occt:
+  - 7.7.2
+openblas:
+  - 0.3.*
+openexr:
+  - '3.2'
+openh264:
+  - '2.3.1'
+openjpeg:
+  - '2'
+openmpi:
+  - 4
+openssl:
+  - '3'
+openturns:
+  - '1.20'
+orc:
+  - 1.9.0
+pango:
+  - 1.50
+pari:
+  - 2.15.* *_pthread
+pcl:
+  - 1.13.1
+perl:
+  - 5.32.1
+petsc:
+  - '3.18'
+petsc4py:
+  - '3.18'
+slepc:
+  - '3.18'
+slepc4py:
+  - '3.18'
+svt_av1:
+  - 1.7.0
+p11_kit:
+  - '0.24'
+pcre:
+  - '8'
+pcre2:
+  - '10.40'
+pixman:
+  - 0
+poco:
+  - 1.12.4
+poppler:
+  - '23.07'
+postgresql:
+  - 15
+postgresql_plpython:
+  - 15
+proj:
+  - 9.2.1
+pulseaudio:
+  - '16.1'
+pulseaudio_client:
+  - '16.1'
+pulseaudio_daemon:
+  - '16.1'
+pybind11_abi:
+  - 4
+python:
+  # part of a zip_keys: python, python_impl, numpy
+  - 3.8.* *_cpython
+  - 3.9.* *_cpython
+  - 3.10.* *_cpython
+  - 3.11.* *_cpython
+python_impl:
+  # part of a zip_keys: python, python_impl, numpy
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+pytorch:
+  - '2.0'
+pyqt:
+  - 5.15
+pyqtwebengine:
+  - 5.15
+pyqtchart:
+  - 5.15
+qt:
+  - 5.15
+qt_main:
+  - 5.15
+qt6_main:
+  - '6.5'
+qtkeychain:
+  - '0.14'
+re2:
+  - 2023.03.02
+readline:
+  - "8"
+rocksdb:
+  - '7.9'
+root_base:
+  - 6.28.4
+ruby:
+  - 2.5
+  - 2.6
+r_base:
+  - 4.1   # [win]
+  - 4.2   # [not win]
+scotch:
+  - 6.0.9
+ptscotch:
+  - 6.0.9
+s2n:
+  - 1.3.54
+sdl2:
+  - '2'
+sdl2_image:
+  - '2'
+sdl2_mixer:
+  - '2'
+sdl2_net:
+  - '2'
+sdl2_ttf:
+  - '2'
+singular:
+  - 4.2.1.p3
+snappy:
+  - 1
+soapysdr:
+  - '0.8'
+sox:
+  - 14.4.2
+spdlog:
+  - '1.11'
+# keep sqlite in sync with libsqlite
+sqlite:
+  - 3
+srm_ifce:
+  - 1.24.6
+starlink_ast:
+  - '9.2.7'
+suitesparse:
+  - 5
+superlu_dist:
+  - 7.1.1
+tbb:
+  - '2021'
+tbb_devel:
+  - '2021'
+thrift_cpp:
+  - 0.18.1
+tinyxml2:
+  - 9
+tk:
+  - 8.6                # [not ppc64le]
+tiledb:
+  - '2.16'
+ucx:
+  - '1.15.0'
+uhd:
+  - 4.5.0
+urdfdom:
+  - 3.1
+vc:                    # [win]
+  - 14                 # [win]
+vlfeat:
+  - 0.9.21
+volk:
+  - '3.0'
+vtk:
+  - 9.2.5
+wcslib:
+  - '8'
+wxwidgets:
+  - '3.2'
+x264:
+  - '1!164.*'
+x265:
+  - '3.5'
+xerces_c:
+  - 3.2
+xrootd:
+  - '5'
+xz:
+  - 5
+zeromq:
+  - 4.3.4
+zfp:
+  - 1.0
+zlib:
+  - 1.2
+zlib_ng:
+  - 2.0
+zstd:
+  - '1.5'

--- a/elfutils/meta.yaml
+++ b/elfutils/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.187" %}
+{% set version = "0.189" %}
 
 package:
   name: elfutils
@@ -7,7 +7,7 @@ package:
 source:
   fn: elfutils-{{ version }}.tar.bz2
   url: https://fedorahosted.org/releases/e/l/elfutils/{{ version }}/elfutils-{{ version }}.tar.bz2
-  sha256: e70b0dfbe610f90c4d1fe0d71af142a4e25c3c4ef9ebab8d2d72b65159d454c8
+  sha256: 39bd8f1a338e2b7cd4abc3ff11a0eddc6e690f69578a57478d8179b4148708c8
 
 build:
   number: 0


### PR DESCRIPTION
Also bump the elfutils version to 0.189 which shouldn't have any effect. This resolves an issue where elfutils was relying a too-old version of libcurl.