### PR TITLE
Enable debuginfod for gdb and elfutils

### DIFF
--- a/elfutils/build.sh
+++ b/elfutils/build.sh
@@ -15,7 +15,7 @@ else
     export LIBS="$(pkg-config --libs-only-l zlib) $LIBS"
     export LDFLAGS="$(pkg-config --libs-only-L zlib) -lrt $LDFLAGS"
     export CFLAGS="$(pkg-config --cflags zlib) -Wno-unused-but-set-variable -Wno-unused-variable -Wno-null-dereference $CFLAGS"
-    ./configure --prefix=$PREFIX --with-zlib --enable-libdebuginfod=dummy || (cat config.log && exit 1)
+    ./configure --prefix=$PREFIX --with-zlib || (cat config.log && exit 1)
     make -j${CPU_COUNT}
 
     # Unfortunately some tests fail, so we can't run "make check" here.

--- a/elfutils/meta.yaml
+++ b/elfutils/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: elfutils
-  version: {{ version }}.memfault0_libdebuginfod
+  version: {{ version }}.memfault1
 
 source:
   fn: elfutils-{{ version }}.tar.bz2

--- a/elfutils/meta.yaml
+++ b/elfutils/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: elfutils
-  version: {{ version }}.memfault0
+  version: {{ version }}.memfault0_libdebuginfod
 
 source:
   fn: elfutils-{{ version }}.tar.bz2

--- a/gdb-multi-arch/build.sh
+++ b/gdb-multi-arch/build.sh
@@ -27,6 +27,7 @@ export CFLAGS="$CFLAGS -Wno-constant-logical-operand -Wno-format-nonliteral -Wno
     --with-zlib \
     --without-babeltrace \
     --with-python="$PREFIX" \
+    --with-debuginfod \
     --disable-ld \
     --disable-gprof \
     --disable-gas \

--- a/gdb-multi-arch/build.sh
+++ b/gdb-multi-arch/build.sh
@@ -11,6 +11,13 @@ export REAL_TARGET_PREFIX="${PREFIX}/${REAL_TARGET}"
 
 export CPPFLAGS="$CPPFLAGS -fcommon -I$PREFIX/include -Wno-constant-logical-operand"
 export CFLAGS="$CFLAGS -Wno-constant-logical-operand -Wno-format-nonliteral -Wno-self-assign"
+
+if [ `uname` == Darwin ]; then
+  EXTRA_CONFIGURE_FLAGS=""
+else
+  EXTRA_CONFIGURE_FLAGS="--with-debuginfod"
+fi
+
 # Setting /usr/lib/debug as debug dir makes it possible to debug the system's
 # python on most Linux distributions
 ./configure \
@@ -27,7 +34,7 @@ export CFLAGS="$CFLAGS -Wno-constant-logical-operand -Wno-format-nonliteral -Wno
     --with-zlib \
     --without-babeltrace \
     --with-python="$PREFIX" \
-    --with-debuginfod \
+    $EXTRA_CONFIGURE_FLAGS \
     --disable-ld \
     --disable-gprof \
     --disable-gas \

--- a/gdb-multi-arch/conda_build_config.yaml
+++ b/gdb-multi-arch/conda_build_config.yaml
@@ -313,7 +313,7 @@ dcap:
 eclib:
   - '20230424'
 elfutils:
-  - 0.189.memfault0_libdebuginfod
+  - 0.189.memfault1
 exiv2:
   - 0.27
 expat:

--- a/gdb-multi-arch/conda_build_config.yaml
+++ b/gdb-multi-arch/conda_build_config.yaml
@@ -313,7 +313,7 @@ dcap:
 eclib:
   - '20230424'
 elfutils:
-  - 0.189
+  - 0.189.memfault0_libdebuginfod
 exiv2:
   - 0.27
 expat:

--- a/gdb-multi-arch/meta.yaml
+++ b/gdb-multi-arch/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - mpfr {{ mpfr }}
     - gmp {{ gmp }}
     - expat {{ expat }} # [linux]
+    # For libdebuginfod:
+    - elfutils
   run:
     - python {{ python }}
     - ncurses {{ ncurses }}
@@ -44,6 +46,8 @@ requirements:
     - mpfr {{ mpfr }}
     - gmp {{ gmp }}
     - expat {{ expat }} # [linux]
+    # For libdebuginfod:
+    - elfutils
 
 test:
   commands:

--- a/gdb-multi-arch/meta.yaml
+++ b/gdb-multi-arch/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault0
+  version: {{ version }}.memfault1
 
 source:
   - url: https://github.com/bminor/binutils-gdb/archive/gdb-{{ version }}-release.tar.gz

--- a/gdb-xtensa-esp32-elf/build.sh
+++ b/gdb-xtensa-esp32-elf/build.sh
@@ -51,6 +51,12 @@ cp -R "${GDB_DIST}"/lib "$TARGET_PREFIX"/
 # Restore PREFIX variable
 PREFIX=${_PREFIX}
 
+if [ `uname` == Darwin ]; then
+  EXTRA_CONFIGURE_FLAGS=""
+else
+  EXTRA_CONFIGURE_FLAGS="--with-debuginfod"
+fi
+
 # Configure, build, and install gdb
 ./configure \
     --prefix="${TARGET_PREFIX}" \
@@ -67,6 +73,7 @@ PREFIX=${_PREFIX}
     --with-zlib \
     --without-babeltrace \
     --with-python="$PREFIX" \
+    $EXTRA_CONFIGURE_FLAGS \
     --disable-threads \
     --disable-sim \
     --disable-nls \

--- a/gdb-xtensa-esp32-elf/conda_build_config.yaml
+++ b/gdb-xtensa-esp32-elf/conda_build_config.yaml
@@ -327,7 +327,7 @@ dcap:
 eclib:
   - '20230424'
 elfutils:
-  - 0.189
+  - 0.189.memfault1
 exiv2:
   - 0.27
 expat:

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - mpfr {{ mpfr }}
     - gmp {{ gmp }}
     - expat {{ expat }}
+    # For libdebuginfod:
+    - elfutils
   run:
     - python {{ python }}
     - ncurses {{ ncurses }}
@@ -44,6 +46,8 @@ requirements:
     - mpfr {{ mpfr }}
     - gmp {{ gmp }} # [not osx]
     - expat {{ expat }} # [not osx]
+    # For libdebuginfod:
+    - elfutils
 
 test:
   commands:

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault3
+  version: {{ version }}.memfault4
 
 source:
   - git_url: https://github.com/espressif/binutils-gdb.git

--- a/gdb-xtensa-lx106-elf/build.sh
+++ b/gdb-xtensa-lx106-elf/build.sh
@@ -13,6 +13,12 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
 
 cd binutils-gdb-lx106-src
 
+if [ `uname` == Darwin ]; then
+  EXTRA_CONFIGURE_FLAGS=""
+else
+  EXTRA_CONFIGURE_FLAGS="--with-debuginfod"
+fi
+
 ./configure \
     --prefix="${TARGET_PREFIX}" \
     --target=$TARGET \
@@ -25,6 +31,7 @@ cd binutils-gdb-lx106-src
     --with-zlib \
     --without-babeltrace \
     --with-python="$PREFIX" \
+    $EXTRA_CONFIGURE_FLAGS \
     --disable-threads \
     --disable-sim \
     --disable-nls \

--- a/gdb-xtensa-lx106-elf/conda_build_config.yaml
+++ b/gdb-xtensa-lx106-elf/conda_build_config.yaml
@@ -313,7 +313,7 @@ dcap:
 eclib:
   - '20230424'
 elfutils:
-  - 0.189
+  - 0.189.memfault1
 exiv2:
   - 0.27
 expat:

--- a/gdb-xtensa-lx106-elf/meta.yaml
+++ b/gdb-xtensa-lx106-elf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xtensa-lx106-elf-gdb" %}
-{% set version = "11.1_20220318.memfault1" %}
+{% set version = "11.1_20220318.memfault2" %}
 
 package:
   name: {{ name }}

--- a/gdb-xtensa-lx106-elf/meta.yaml
+++ b/gdb-xtensa-lx106-elf/meta.yaml
@@ -37,6 +37,8 @@ requirements:
     - mpfr {{ mpfr }}
     - gmp {{ gmp }}
     - expat {{ expat }} # [linux]
+    # For libdebuginfod:
+    - elfutils
   run:
     - python {{ python }}
     - ncurses {{ ncurses }}
@@ -46,6 +48,8 @@ requirements:
     - mpfr {{ mpfr }}
     - gmp {{ gmp }}
     - expat {{ expat }} # [linux]
+    # For libdebuginfod:
+    - elfutils
 
 test:
   commands:


### PR DESCRIPTION
- Configure elfutils to also build libdebuginfod
- Configure gdb to build with libdebuginfod