### PR TITLE
Use conda for our fork of ecs-cli

### DIFF
--- a/memfault-ecs-cli/README.md
+++ b/memfault-ecs-cli/README.md
@@ -1,0 +1,1 @@
+Probably not useful for public consumption - forked version of amazon-ecs-cli to apply Memfault-specific tweaks.

--- a/memfault-ecs-cli/build.sh
+++ b/memfault-ecs-cli/build.sh
@@ -2,5 +2,4 @@
 
 mkdir $PREFIX/bin
 cp $SRC_DIR/ecs-cli* $PREFIX/bin
-mv $PREFIX/bin/ecs-cli* $PREFIX/bin/ecs-cli
 chmod +x $PREFIX/bin/ecs-cli

--- a/memfault-ecs-cli/build.sh
+++ b/memfault-ecs-cli/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir $PREFIX/bin
+cp $SRC_DIR/ecs-cli* $PREFIX/bin
+mv $PREFIX/bin/ecs-cli* $PREFIX/bin/ecs-cli
+chmod +x $PREFIX/bin/ecs-cli

--- a/memfault-ecs-cli/meta.yaml
+++ b/memfault-ecs-cli/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "ecs-cli" %}
-{% set version = "1.21.0.memfault0" %}
+{% set version = "1.21.0" %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version }}.memfault0
 
 source:
   url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}/ecs-cli.darwin-amd64 # [osx]

--- a/memfault-ecs-cli/meta.yaml
+++ b/memfault-ecs-cli/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ecs-cli" %}
-{% set version = "1.21.0.mflt" %}
+{% set version = "1.21.0.memfault0" %}
 
 package:
   name: {{ name }}
@@ -10,6 +10,7 @@ source:
   sha256: 13c631695ada3d14ecdeb6ea4896ab4e94bf9e3a6f574b2ed57596643f0db496 # [osx]
   url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}/ecs-cli.linux-amd64 # [linux64]
   sha256: 80f7eee721e1b0268173c8a5a1400486ddae409d737b6c0f4b5fd58baa37e2bb # [linux64]
+  fn: ecs-cli
 
 build:
   string: '0'

--- a/memfault-ecs-cli/meta.yaml
+++ b/memfault-ecs-cli/meta.yaml
@@ -1,0 +1,22 @@
+{% set name = "ecs-cli" %}
+{% set version = "1.21.0.mflt" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}/ecs-cli.darwin-amd64 # [osx]
+  sha256: 13c631695ada3d14ecdeb6ea4896ab4e94bf9e3a6f574b2ed57596643f0db496 # [osx]
+  url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}/ecs-cli.linux-amd64 # [linux64]
+  sha256: 80f7eee721e1b0268173c8a5a1400486ddae409d737b6c0f4b5fd58baa37e2bb # [linux64]
+
+build:
+  string: '0'
+
+test:
+  commands:
+    - ecs-cli --version
+
+about:
+  home: https://github.com/memfault/memfault-ecs-cli


### PR DESCRIPTION
Recipe for our newly forked version of ecs-cli.

# Test Plan

It builds just fine, and is able to execute `ecs-cli --version` as expected. Once published, I'll ensure I can reference it from within my local environment.
```
(build) dansubak@Daniels-MacBook-Pro memfault-ecs-cli % conda build -c conda-forge .                       
/Users/dansubak/mambaforge/envs/build/bin/conda-build:11: DeprecationWarning: conda_build.cli.main_build.main is deprecated and will be removed in 4.0.0. Use `conda build` instead.
  sys.exit(main())
WARNING: No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.22
Adding in variants from internal_defaults
Attempting to finalize metadata for ecs-cli
BUILD START: ['ecs-cli-1.21.0.mflt-0.tar.bz2']
Source cache directory is: /Users/dansubak/mambaforge/envs/build/conda-bld/src_cache
Found source in cache: ecs-cli_13c631695a.darwin-amd64
Extracting download
Warning: Unrecognized source format. Source file will be copied to the SRC_DIR
source tree in: /Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700594382301/work
export PREFIX=/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700594382301/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol
export SRC_DIR=/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700594382301/work

Resource usage statistics from building ecs-cli:
   Process count: 1
   CPU time: Sys=0:00:00.0, User=0:00:00.0
   Memory: 2.7M
   Disk usage: 99.1K
   Time elapsed: 0:00:02.0


Packaging ecs-cli
Packaging ecs-cli-1.21.0.mflt-0
number of files: 1
<Log noise snipped>
The following NEW packages will be INSTALLED:

    ecs-cli: 1.21.0.mflt-0 local

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
export PREFIX=/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700594382301/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla
export SRC_DIR=/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700594382301/test_tmp
+ ecs-cli --version
ecs-cli version 1.21.0 (*2791f9b)
+ exit 0
```