### PR TITLE
Update hash to reference newly uploaded binaries

### DIFF
--- a/memfault-ecs-cli/meta.yaml
+++ b/memfault-ecs-cli/meta.yaml
@@ -7,9 +7,9 @@ package:
 
 source:
   url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}/ecs-cli.darwin-amd64 # [osx]
-  sha256: 13c631695ada3d14ecdeb6ea4896ab4e94bf9e3a6f574b2ed57596643f0db496 # [osx]
+  sha256: d1cfdb47a22bb940166c2bf03ff451fa4e450bad25d0c9d8d4e2828bed01a791 # [osx]
   url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}/ecs-cli.linux-amd64 # [linux64]
-  sha256: 80f7eee721e1b0268173c8a5a1400486ddae409d737b6c0f4b5fd58baa37e2bb # [linux64]
+  sha256: 0409d1bfe6fc5afdebae5846b1eb347df8554324e14ec0919060355657704c21 # [linux64]
   fn: ecs-cli
 
 build:


### PR DESCRIPTION
Unfortunately, when uploading binaries for the release yesterday, I accidentally uploaded ones built without our modification.

We want our changes built off of https://github.com/memfault/memfault-ecs-cli/commit/75eb5856f6bf63e731a46a2ba193a367f1e6b6f5, and I've rebuilt and reuploaded the binaries in https://github.com/memfault/memfault-ecs-cli/releases/tag/1.21.0 to reflect that.

## Test Plan
Builds locally with command `conda build -c conda-forge .`
```
<output snipped>
export SRC_DIR=/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700684638754/test_tmp
+ ecs-cli --version
ecs-cli version 1.21.0 (*75eb585)
+ exit 0

Resource usage statistics from testing ecs-cli:
   Process count: 3
   CPU time: Sys=0:00:00.0, User=0:00:00.0
   Memory: 15.2M
   Disk usage: 24B
   Time elapsed: 0:00:02.0


TEST END: /Users/dansubak/mambaforge/envs/build/conda-bld/osx-arm64/ecs-cli-1.21.0.memfault0-0.conda
Renaming work directory '/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700684638754/work' to '/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700684638754/work_moved_ecs-cli-1.21.0.memfault0-0_osx-arm64_main_build_loop'
shutil.move(work)=/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700684638754/work, dest=/Users/dansubak/mambaforge/envs/build/conda-bld/ecs-cli_1700684638754/work_moved_ecs-cli-1.21.0.memfault0-0_osx-arm64_main_build_loop)
# Automatic uploading is disabled
# If you want to upload package(s) to anaconda.org later, type:


# To have conda build upload to anaconda.org automatically, use
# conda config --set anaconda_upload yes
anaconda upload \
    /Users/dansubak/mambaforge/envs/build/conda-bld/osx-arm64/ecs-cli-1.21.0.memfault0-0.conda
anaconda_upload is not set.  Not uploading wheels: []

INFO :: The inputs making up the hashes for the built packages are as follows:
{
  "ecs-cli-1.21.0.memfault0": {
    "recipe": {}
  }
}

```

Of note in the above, you can see that `ecs-cli --version` returns the commit hash we want instead of the old busted one.

## Deploy plan
Will kick off another GH Action run to get these built, then upload the resulting binaries as per the README. I'll start with the osx one and test locally to see if `bin/setup.py` picks up the new binary without additional intervention. Assuming it does, everything should work without any additional work.