### PR TITLE
Bump version and sha256 for new version of ecs-cli

### DIFF
--- a/memfault-ecs-cli/meta.yaml
+++ b/memfault-ecs-cli/meta.yaml
@@ -3,13 +3,13 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault0
+  version: {{ version }}.memfault1
 
 source:
   url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}/ecs-cli.darwin-amd64 # [osx]
-  sha256: d1cfdb47a22bb940166c2bf03ff451fa4e450bad25d0c9d8d4e2828bed01a791 # [osx]
+  sha256: 4050e9aad0bb32a6b5d868e3e4d67b874eb1adb598d7214778555611ca2c934b # [osx]
   url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}/ecs-cli.linux-amd64 # [linux64]
-  sha256: 0409d1bfe6fc5afdebae5846b1eb347df8554324e14ec0919060355657704c21 # [linux64]
+  sha256: c5bf1f19b869db6e94f9b331541bd7fcf2a559df22dd41428857dd73a0aae878 # [linux64]
   fn: ecs-cli
 
 build:


### PR DESCRIPTION
Use the new release cut against https://github.com/memfault/memfault-ecs-cli/pull/2. This adds a check for when the ecs network mode is not `awsvpc` and specifies a network kernel tuning only if that is the case.