### PR TITLE
chore(aws-vault): Update aws-vault to 7.2.0

### DIFF
--- a/aws-vault/meta.yaml
+++ b/aws-vault/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-vault" %}
-{% set version = "6.6.0" %}
+{% set version = "7.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/99designs/aws-vault/releases/download/v{{ version }}/aws-vault-darwin-amd64.dmg # [osx and x86_64]
-  sha256: eeb7b8dbdba7bb18fcf32e1c422683d5fd444c6c3b5eb41e760bbfcb2036df6c # [osx and x86_64]
+  sha256: c0642de33329eb6eade70532f0c9eb769d2a1b52dfa56b63196ef51c7dea6445 # [osx and x86_64]
   url: https://github.com/99designs/aws-vault/releases/download/v{{ version }}/aws-vault-darwin-arm64.dmg # [osx and arm64]
-  sha256: 7c624f16a60f6d48900d7aa7f17add991376f1d280e8a5168094e19098797c35 # [osx and arm64]
+  sha256: 9887eb8f6c2bd431e814b32b9ec8a6bd394dbeb0c60822d76ed9be3c84ca1cc5 # [osx and arm64]
   url: https://github.com/99designs/aws-vault/releases/download/v{{ version }}/aws-vault-linux-amd64 # [linux64 and x86_64]
-  sha256: f4571f90a4847ea42c239ebbef058d18baccfe9f28092ace84f348c7cd29aa19 # [linux64 and x86_64]
+  sha256: b92bcfc4a78aa8c547ae5920d196943268529c5dbc9c5aca80b797a18a5d0693 # [linux64 and x86_64]
 
 build:
   string: '1'


### PR DESCRIPTION
### Issues addressed
aws-vault added support for `sso-session` in 7.0.0, and I'd like to
use this feature to reduce boilerplate.

I've also noticed a few rough edges which may have been ironed out in
the past 2 years since our last version bump.

 ### Summary
Version bump!

I built for linux and uploaded:

```
$ anaconda --user <redacted> --token <redacted> upload /home/topher/mambaforge/envs/build/conda-bld/linux-64/aws-vault-7.2.0-1.conda
```

I'm not sure how to build for the two Darwin builds... can someone give
me a hint? (or does someone with a mac have to do it? that feels like it
might be likely).

 ### Test Plan
- [ ] Will run locally for a bit to ensure it works as expected.