### PR TITLE
feat: Try GDBs with python3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     name: 🛠️ build on ${{ matrix.platform }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         platform: [ubuntu-20.04, macos-11, macos-13-xlarge] #  windows-2022] windows is a bit sad :'(
     runs-on: ${{ matrix.platform }}

--- a/elfutils/conda_build_config.yaml
+++ b/elfutils/conda_build_config.yaml
@@ -605,6 +605,7 @@ numpy:
   - 1.22
   - 1.22
   - 1.23
+  - 1.25
 occt:
   - 7.7.2
 openblas:
@@ -673,8 +674,10 @@ python:
   - 3.9.* *_cpython
   - 3.10.* *_cpython
   - 3.11.* *_cpython
+  - 3.12.* *_cpython
 python_impl:
   # part of a zip_keys: python, python_impl, numpy
+  - cpython
   - cpython
   - cpython
   - cpython

--- a/elfutils/meta.yaml
+++ b/elfutils/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: elfutils
-  version: {{ version }}.memfault1
+  version: {{ version }}.memfault2
 
 source:
   fn: elfutils-{{ version }}.tar.bz2

--- a/gdb-multi-arch/build.sh
+++ b/gdb-multi-arch/build.sh
@@ -41,7 +41,7 @@ fi
     --disable-sim \
     --disable-gold \
     --enable-64-bit-bfd
-make
+make -j${CPU_COUNT}
 make install
 
 # Move from the fake to real directory

--- a/gdb-multi-arch/conda_build_config.yaml
+++ b/gdb-multi-arch/conda_build_config.yaml
@@ -313,7 +313,7 @@ dcap:
 eclib:
   - '20230424'
 elfutils:
-  - 0.189.memfault1
+  - 0.189.memfault2
 exiv2:
   - 0.27
 expat:
@@ -605,6 +605,7 @@ numpy:
   - 1.22
   - 1.22
   - 1.23
+  - 1.25
 occt:
   - 7.7.2
 openblas:
@@ -673,8 +674,10 @@ python:
   - 3.9.* *_cpython
   - 3.10.* *_cpython
   - 3.11.* *_cpython
+  - 3.12.* *_cpython
 python_impl:
   # part of a zip_keys: python, python_impl, numpy
+  - cpython
   - cpython
   - cpython
   - cpython

--- a/gdb-multi-arch/meta.yaml
+++ b/gdb-multi-arch/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault1
+  version: {{ version }}.memfault2
 
 source:
   - url: https://github.com/bminor/binutils-gdb/archive/gdb-{{ version }}-release.tar.gz

--- a/gdb-multi-arch/meta.yaml
+++ b/gdb-multi-arch/meta.yaml
@@ -51,7 +51,8 @@ requirements:
 
 test:
   commands:
-    - gdb -ex "print 1" --batch
+    - gdb --version
+    - gdb -nx --batch -ex "print 1"
 
 about:
   home: https://www.gnu.org/software/gdb/

--- a/gdb-xtensa-esp32-elf/conda_build_config.yaml
+++ b/gdb-xtensa-esp32-elf/conda_build_config.yaml
@@ -327,7 +327,7 @@ dcap:
 eclib:
   - '20230424'
 elfutils:
-  - 0.189.memfault1
+  - 0.189.memfault2
 exiv2:
   - 0.27
 expat:
@@ -611,6 +611,8 @@ numpy:
   - 1.21
   - 1.21
   - 1.21
+  - 1.23
+  - 1.25
 occt:
   - '7.7'
 openblas:
@@ -674,8 +676,12 @@ python:
   - 3.8.* *_cpython
   - 3.9.* *_cpython
   - 3.10.* *_cpython
+  - 3.11.* *_cpython
+  - 3.12.* *_cpython
 python_impl:
   # part of a zip_keys: python, python_impl, numpy
+  - cpython
+  - cpython
   - cpython
   - cpython
   - cpython

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault4
+  version: {{ version }}.memfault5
 
 source:
   - git_url: https://github.com/espressif/binutils-gdb.git

--- a/gdb-xtensa-lx106-elf/conda_build_config.yaml
+++ b/gdb-xtensa-lx106-elf/conda_build_config.yaml
@@ -313,7 +313,7 @@ dcap:
 eclib:
   - '20230424'
 elfutils:
-  - 0.189.memfault1
+  - 0.189.memfault2
 exiv2:
   - 0.27
 expat:
@@ -605,6 +605,7 @@ numpy:
   - 1.22
   - 1.22
   - 1.23
+  - 1.25
 occt:
   - 7.7.2
 openblas:
@@ -673,8 +674,10 @@ python:
   - 3.9.* *_cpython
   - 3.10.* *_cpython
   - 3.11.* *_cpython
+  - 3.12.* *_cpython
 python_impl:
   # part of a zip_keys: python, python_impl, numpy
+  - cpython
   - cpython
   - cpython
   - cpython

--- a/gdb-xtensa-lx106-elf/meta.yaml
+++ b/gdb-xtensa-lx106-elf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xtensa-lx106-elf-gdb" %}
-{% set version = "11.1_20220318.memfault2" %}
+{% set version = "11.1_20220318.memfault3" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
### Summary

Try updating GDB recipes to use python3.12 as well when building

I could not get all to build locally with this, but some did

I will reach out for build support

