### PR TITLE
feat(clickhouse): version 24.4.1.2088

### DIFF
--- a/clickhouse/meta.yaml
+++ b/clickhouse/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "clickhouse" %}
-{% set version = "24.1.8.22" %}
+{% set version = "24.4.1.2088" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   - url: https://github.com/ClickHouse/ClickHouse/releases/download/v{{ version }}-stable/clickhouse-macos # [osx and x86_64]
-    sha256: 1f171f23f32e41ee7b54a0720a3e524e39a56aab541bcc8b05026246f2b16375 # [osx and x86_64]
+    sha256: ebbdda46725aaa81c2d79afcf0be3d67c53a28d1ad355117208b20b295044de3 # [osx and x86_64]
   - url: https://github.com/ClickHouse/ClickHouse/releases/download/v{{ version }}-stable/clickhouse-macos-aarch64 # [osx and arm64]
-    sha256: acc16471f7f9b77580ef31dc5f6f22b4481e73565aa7b9b1bc5cbd5b54fc9c1d # [osx and arm64]
+    sha256: df52242a6730612673fec254e30bc1cc7fe34c356bf06b52bc0dba3cf006aba0 # [osx and arm64]
   - url: https://github.com/ClickHouse/ClickHouse/releases/download/v{{ version }}-stable/clickhouse-common-static-{{ version }}-amd64.tgz # [linux64]
-    sha256: 9e1b654c3e255c730203ad8c0cd724a06c7d2b29a7f615ccca52d487936b3d44 # [linux64]
+    sha256: 63e1ad946bf6b44acce896387afa02983518517bd629625f7e41fdf44cc8922f # [linux64]
 
 build:
   number: 0


### PR DESCRIPTION
### Summary

Packaging and config for ClickHouse 24.4.1.2088

macOS packages uploaded from my machine, Linux from the build GH action