### PR TITLE
chore: Version-bump gitleaks

### DIFF
--- a/gitleaks/meta.yaml
+++ b/gitleaks/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "gitleaks" %}
-{% set version = "8.8.4" %}
+{% set version = "8.18.4" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  # bash for getting the sigs:
-  # ❯ (GITLEAKS_VER=8.8.4; for _arch in darwin_x64 linux_x64; do curl -sSL https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_VER}/gitleaks_${GITLEAKS_VER}_${_arch}.tar.gz | sha256sum; done)
+  # get the checksums from the checksum file, included in the release
   url: https://github.com/zricethezav/gitleaks/releases/download/v{{ version }}/gitleaks_{{ version }}_darwin_x64.tar.gz # [osx and x86_64]
-  sha256: 509430dada69ee4314068847a8a424d4102defc23fd5714330d36366796feef7 # [osx and x86_64]
+  sha256: 1a69e5666b13cd374889cbcb1939ed1573b63b551251283d5d2329a53cf58e2f # [osx and x86_64]
   url: https://github.com/zricethezav/gitleaks/releases/download/v{{ version }}/gitleaks_{{ version }}_darwin_arm64.tar.gz # [osx and arm64]
-  sha256: 205dfb78a2d8b6ef6837f73892a7c4ca92f02809e70b725ec50cefaab4c4ae29 # [osx and arm64]
+  sha256: a480d8593acd8215b22402cf0f3f88b01dcd3610c63b5391db640f7767e62104 # [osx and arm64]
   url: https://github.com/zricethezav/gitleaks/releases/download/v{{ version }}/gitleaks_{{ version }}_linux_x64.tar.gz # [linux64]
-  sha256: f8d4b82a14141427af1f89de1b24ed7fe2e1c6542ed91acde9618d04c068ecbd # [linux64]
+  sha256: ba6dbb656933921c775ee5a2d1c13a91046e7952e9d919f9bac4cec61d628e7d # [linux64]
 
 build:
   string: '1'


### PR DESCRIPTION
### Issues addressed
Modern versions of gitleaks include a `--no-banner` option.

### Summary of changes
Ran locally:

```
$ conda build -c conda-forge .
anaconda upload \
    /home/topher/mambaforge/envs/build/conda-bld/linux-64/gitleaks-8.18.4-1.conda
```

Then I was able to use this in the monorepo.