### PR TITLE
chore: Bump deprecated macos version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ubuntu-20.04, macos-11, macos-13-xlarge] #  windows-2022] windows is a bit sad :'(
+        platform: [ubuntu-20.04, macos-12, macos-13-xlarge] #  windows-2022] windows is a bit sad :'(
     runs-on: ${{ matrix.platform }}
 
     # set bash to be a login shell, so that /etc/profile is sourced and conda


### PR DESCRIPTION
### Issues addressed
`macos-11` was deprecated earlier this quarter, failing any jobs which
attempt to use it.

### Summary of changes
Bump the version.

### Test Plan
On the `gitleaks` child PR I will attempt to build packages and grab
their artifacts.