### PR TITLE
docs: Promote using the Github Action for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ channels:
 
 Since all of these packages are built using Conda Forge's package pinnings (https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml), using Conda Forge as the base is heavily suggested.
 
+## Building via GitHub Action
+
+Not heavily tested, but it's possible to build packages from github actions, see
+[`.github/workflows/build.yml`](.github/workflows/build.yml).
+
+To trigger it, set the appropriate `PACKAGE_DIR` when making a pull request.
+
+Note that this may not work if the above `CONDA_BUILD_SYSROOT` is set; you'll
+have to add a step to install the appropriate tools into that location if you
+want to go that route.
+
+From the Github UI, you can [trigger the build by going here](https://github.com/memfault/conda-recipes/actions/workflows/build.yml), then:
+
+- Click "Run Workflow".
+- Enter the package directory in the designated input field.
+- Hit "Run".
+
+Once the Github action has built the packages, they still need to be uploaded to
+anaconda.org manually. Go to the [detail page of your workflow run](https://github.com/memfault/conda-recipes/actions)
+and download the "packages" artifact.
+
+Unzip the packages.zip and then run:
+
+```shell
+PACKAGE=<package_name> anaconda upload **/$PACKAGE*.tar.bz2 --user memfault
+```
+
 ## Building Locally
 
 To build any of the following packages (macOS and Linux Ubuntu 18.04 tested):
@@ -91,36 +118,6 @@ conda config --env --set subdir osx-64
 ```
 
 Then follow the _Building Locally_ instructions at the top.
-
-## Building via GitHub Action
-
-Not heavily tested, but it's possible to build packages from github actions, see
-[`.github/workflows/build.yml`](.github/workflows/build.yml).
-
-To trigger it, set the appropriate `PACKAGE_DIR` when making a pull request.
-
-Note that this may not work if the above `CONDA_BUILD_SYSROOT` is set; you'll
-have to add a step to install the appropriate tools into that location if you
-want to go that route.
-
-From the Github UI, you can [trigger the build by going here](https://github.com/memfault/conda-recipes/actions/workflows/build.yml), then:
-
-- Click "Run Workflow".
-- Enter the package directory in the designated input field.
-- Hit "Run".
-
-Once the Github action has built the packages, they still need to be uploaded to
-anaconda.org manually. Go to the [detail page of your workflow run](https://github.com/memfault/conda-recipes/actions)
-and download the "packages" artifact.
-
-Unzip the packages.zip and then run:
-
-```shell
-PACKAGE=<package_name> anaconda upload **/$PACKAGE*.tar.bz2 --user memfault
-```
-
-> Note: [Github actions cannot be run on Apple ARM VMs](https://github.com/actions/virtual-environments/issues/2187)
-> so building the package for darwin-aarch64 still needs to be done "manually"...
 
 ## Uploading Packages
 


### PR DESCRIPTION
### Summary of changes
Our github action has gotten better by building macos images (N=1, from
building `gitleaks`).

Let's make it more obvious that this is a great path to go down for
building and doesn't require local emulation. I'll move it up in the
README and remove the scary warning.

### Test Plan
I tested the Github Actions flow during the `gitleaks` PR.

I skimmed the text and it looks fine.