### PR TITLE
chore(volta): Make volta_deactivate.sh more portable

### DIFF
--- a/volta/deactivate.sh
+++ b/volta/deactivate.sh
@@ -1,15 +1,25 @@
+#!/bin/bash
+
 # if VOLTA_HOME_PREFERRED is set, don't unset VOLTA_HOME; the user activated the
 # conda environment with VOLTA_HOME already set, and we don't want to mess with
 # it
 if [ -n "$VOLTA_HOME_PREFERRED" ]; then
   unset VOLTA_HOME_PREFERRED
 else
-  # otherwise, clean up after ourselves
+  # remove the directory from PATH
   directory_to_remove=$VOLTA_HOME/bin
-  # from https://unix.stackexchange.com/a/108933
-  PATH=:$PATH:
-  PATH=${PATH//:$directory_to_remove:/:}
-  PATH=${PATH#:}
-  PATH=${PATH%:}
+  new_path=""
+  old_ifs=$IFS
+  IFS=":"
+  for dir in $PATH; do
+    if [ "$dir" != "$directory_to_remove" ]; then
+      new_path="$new_path:$dir"
+    fi
+  done
+  IFS=$old_ifs
+
+  # Remove the leading colon if necessary
+  PATH=${new_path#:}
+
   unset VOLTA_HOME
 fi

--- a/volta/meta.yaml
+++ b/volta/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault2
+  version: {{ version }}.memfault3
 
 source:
   # bash for getting the sigs:


### PR DESCRIPTION
### Issues addressed
I've been getting an issue locally when running volta via lefthook.
Specifically, I'd see an error like this:

```
$ git commit -am Test
.git/hooks/post-checkout: 13: /home/topher/miniforge3/envs/memfault/etc/conda/deactivate.d/volta_deactivate.sh: Bad substitution
ERROR: Command failed with error exit code 1:
```

I tracked the issue down to non-portable bash-specific handling.

### Summary of changes
I _think_ adding the shebang (`#!/bin/bash`) _should_ have been
sufficient here to get my local machine working, however this had no
impact.

I'm not going to spend a ton of time debugging this; I re-wrote it to be
more portable and avoid the problematic field.

### Test Plan
- [x] I can now run `git commit` without error