### PR TITLE
overmind: Update tmux dependency

### DIFF
--- a/overmind/meta.yaml
+++ b/overmind/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   run:
-    - tmux 3.4
+    - tmux 3.5
 
 test:
   commands:


### PR DESCRIPTION
tmux 3.4 has an issue where it crashes the server in terminals that support sixel when some programs like neovim are executed:

https://github.com/neovim/neovim/issues/28827

Updating to 3.5 so that we have the fix.