### PR TITLE
feat: Build elfutils with updated versions

### DIFF
--- a/elfutils/conda_build_config.yaml
+++ b/elfutils/conda_build_config.yaml
@@ -602,9 +602,8 @@ ntl:
 numpy:
   # part of a zip_keys: python, python_impl, numpy
   - 1.22
-  - 1.22
-  - 1.22
   - 1.23
+  - 1.26
 occt:
   - 7.7.2
 openblas:
@@ -669,13 +668,11 @@ pybind11_abi:
   - 4
 python:
   # part of a zip_keys: python, python_impl, numpy
-  - 3.8.* *_cpython
-  - 3.9.* *_cpython
   - 3.10.* *_cpython
   - 3.11.* *_cpython
+  - 3.12.* *_cpython
 python_impl:
   # part of a zip_keys: python, python_impl, numpy
-  - cpython
   - cpython
   - cpython
   - cpython
@@ -791,7 +788,7 @@ zeromq:
 zfp:
   - 1.0
 zlib:
-  - 1.2
+  - 1.3
 zlib_ng:
   - 2.0
 zstd:

--- a/elfutils/meta.yaml
+++ b/elfutils/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: elfutils
-  version: {{ version }}.memfault1
+  version: {{ version }}.memfault2
 
 source:
   fn: elfutils-{{ version }}.tar.bz2


### PR DESCRIPTION
### Summary

In prep for GDB 16 upgrades, we need to build `elfutils` with newer python versions and zlib version.

### Test Plan

- Build it and that's it
