### PR TITLE
feat: Rebuild cmake

### DIFF
--- a/cmake/build.sh
+++ b/cmake/build.sh
@@ -1,19 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
 
-CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_FIND_ROOT_PATH=${PREFIX} -DCMAKE_INSTALL_RPATH=${PREFIX}/lib"
+CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_FIND_ROOT_PATH=${PREFIX}" # -DCMAKE_INSTALL_RPATH=${PREFIX}/lib"
 CMAKE_ARGS="$CMAKE_ARGS -DCURSES_INCLUDE_PATH=${PREFIX}/include -DBUILD_CursesDialog=ON -DCMake_HAVE_CXX_MAKE_UNIQUE:INTERNAL=FALSE"
 CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=${PREFIX}"
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
-   if [[ "$target_platform" == osx-* ]] && [[ "$MACOSX_DEPLOYMENT_TARGET" == 11.* || "$MACOSX_DEPLOYMENT_TARGET" == "10.15" ]]; then
+   if [[ "$TARGET_PLATFORM" == osx-* ]] && [[ "$MACOSX_DEPLOYMENT_TARGET" == 11.* || "$MACOSX_DEPLOYMENT_TARGET" == "10.15" ]]; then
        CMAKE_ARGS="$CMAKE_ARGS -DCMake_HAVE_CXX_FILESYSTEM=1"
    else
        CMAKE_ARGS="$CMAKE_ARGS -DCMake_HAVE_CXX_FILESYSTEM=0"
    fi
    cmake ${CMAKE_ARGS} \
        -DCMAKE_VERBOSE_MAKEFILE=1 \
-       -DCMAKE_INSTALL_PREFIX=$PREFIX \
+       -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
        -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
        -DBUILD_QtDialog=OFF \
        -DCMAKE_USE_SYSTEM_LIBRARY_LIBARCHIVE=OFF \
@@ -27,12 +27,12 @@ else
        --no-qt-gui \
        --no-system-libarchive \
        --no-system-jsoncpp \
-       --parallel=${CPU_COUNT} \
+       --parallel="${CPU_COUNT}" \
        -- \
        ${CMAKE_ARGS}
 fi
 
 # CMake automatically selects the highest C++ standard available
 
-make install -j${CPU_COUNT}
+make install -j"${CPU_COUNT}"
 

--- a/cmake/conda_build_config.yaml
+++ b/cmake/conda_build_config.yaml
@@ -6,14 +6,14 @@ c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
 c_compiler_version:            # [unix]
-  - 12                         # [osx]
-  - 10                         # [linux]
+  - 16                         # [osx]
+  - 12                         # [linux]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
 cxx_compiler_version:          # [unix]
-  - 12                         # [osx]
-  - 10                         # [linux]
+  - 16                         # [osx]
+  - 12                         # [linux]
 
 cdt_name: cos6
 channel_sources: conda-forge,defaults
@@ -37,7 +37,7 @@ ignore_build_only_deps:
 libcurl: '7'
 lua: '5'
 ncurses: '6.2'
-numpy: '1.16'
+numpy: '1.22'
 perl: 5.26.2
 pin_run_as_build:
   python:
@@ -56,7 +56,7 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-python: '3.8'
+python: '3.10'
 r_base: '3.5'
 xz: '5.2'
 zip_keys:
@@ -64,5 +64,7 @@ zip_keys:
   - docker_image
 - - c_compiler_version
   - cxx_compiler_version
-zlib: '1.2'
+zlib:
+- '1.2'
+- '1.3'
 zstd: '1.5'

--- a/cmake/meta.yaml
+++ b/cmake/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: cmake
-  version: {{ version }}.memfault0
+  version: {{ version }}.memfault1
 
 source:
   url: https://github.com/Kitware/CMake/releases/download/v{{ version }}/cmake-{{ version }}.tar.gz
@@ -37,7 +37,7 @@ requirements:
     - expat           # [unix]
     - ncurses         # [unix]
     - xz              # [unix]
-    - zlib            # [unix]
+    - zlib {{ zlib }} # [unix]
     - libuv           # [unix]
     - rhash           # [unix]
     - zstd            # [unix]
@@ -48,7 +48,7 @@ requirements:
     - expat           # [unix]
     - ncurses         # [unix]
     - xz              # [unix]
-    - zlib            # [unix]
+    - zlib {{ zlib }} # [unix]
     - libuv           # [unix]
     - rhash           # [unix]
     - zstd            # [unix]


### PR DESCRIPTION
### Summary

I'm not sure if this is a needed change, but this allows `cmake` to depend on
`zlib 1.3`. I'm not actually sure it needs `zlib` at all however, but I don't
wanna do that rabbit hole atm.

Doesn't bump anything except min things required to build on a modern env.

### Test Plan

- Builds locally on `osx-arm64`
- Building on Github Actions: TODO
