### PR TITLE
migrate aws-vault to (maintained) ByteNess fork

### DIFF
--- a/aws-vault/README.md
+++ b/aws-vault/README.md
@@ -1,1 +1,1 @@
-A repackage of [99designs/aws-vault](https://github.com/99designs/aws-vault) for Conda environments.
+A repackage of [ByteNess/aws-vault](https://github.com/ByteNess/aws-vault) for Conda environments.

--- a/aws-vault/build.sh
+++ b/aws-vault/build.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-mkdir $PREFIX/bin
-
-if [ `uname` == Darwin ]; then
-    echo "Mounting the disk image"
-    DMG=`ls $SRC_DIR/aws-vault*`
-    MOUNT_POINT=`hdiutil attach $DMG| tail -n 1 | cut -f 1 -d" "`
-    MOUNT_LOCATION=`mount | grep $MOUNT_POINT | cut -d" " -f 3`
-
-    cp $MOUNT_LOCATION/aws-vault $PREFIX/bin
-
-    hdiutil detach $MOUNT_LOCATION
-else
-    cp $SRC_DIR/aws-vault* $PREFIX/bin/aws-vault
-fi
-
+mkdir -p $PREFIX/bin
+cp $SRC_DIR/aws-vault* $PREFIX/bin/aws-vault
 chmod +x $PREFIX/bin/aws-vault

--- a/aws-vault/meta.yaml
+++ b/aws-vault/meta.yaml
@@ -1,27 +1,26 @@
 {% set name = "aws-vault" %}
-{% set version = "7.2.0" %}
+{% set version = "7.9.3" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/99designs/aws-vault/releases/download/v{{ version }}/aws-vault-darwin-amd64.dmg # [osx and x86_64]
-  sha256: c0642de33329eb6eade70532f0c9eb769d2a1b52dfa56b63196ef51c7dea6445 # [osx and x86_64]
-  url: https://github.com/99designs/aws-vault/releases/download/v{{ version }}/aws-vault-darwin-arm64.dmg # [osx and arm64]
-  sha256: 9887eb8f6c2bd431e814b32b9ec8a6bd394dbeb0c60822d76ed9be3c84ca1cc5 # [osx and arm64]
-  url: https://github.com/99designs/aws-vault/releases/download/v{{ version }}/aws-vault-linux-amd64 # [linux64 and x86_64]
-  sha256: b92bcfc4a78aa8c547ae5920d196943268529c5dbc9c5aca80b797a18a5d0693 # [linux64 and x86_64]
+  url: https://github.com/ByteNess/aws-vault/releases/download/v{{ version }}/aws-vault-darwin-arm64 # [osx and arm64]
+  sha256: 54c7a2cb4862b239b7795e6442e0853d7ba71c7a8403cdbfd6a76128a797fb00 # [osx and arm64]
+  url: https://github.com/ByteNess/aws-vault/releases/download/v{{ version }}/aws-vault-linux-amd64 # [linux64 and x86_64]
+  sha256: 5917c87f74bacbd4a639830adb75f27c180e75a65ad3d1faef02cf3935c4fd9b # [linux64 and x86_64]
 
 build:
   string: '1'
   binary_relocation: False
+  skip: True  # [osx and x86_64]
 
 test:
   commands:
     - aws-vault --version
 
 about:
-  home: https://github.com/99designs/aws-vault
+  home: https://github.com/ByteNess/aws-vault
   license: MIT
   summary: AWS Vault is a tool to securely store and access AWS credentials in a development environment


### PR DESCRIPTION
### Issues Addressed

aws-vault has archived their repo: https://github.com/99designs/aws-vault

This is the recommended fork: https://github.com/ByteNess/aws-vault

### Summary

Migrate.

The new repo moved from `.dmg` files to plain binaries, so I _think_
this simplifies the macos installation step and the new script is correct.

### Test Plan

- [x] ran locally on my linux machine
- get a macos dev to test (will do on the memfault repo PR)