### PR TITLE
chore(git): Add PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/2_optional_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/2_optional_template.md
@@ -1,0 +1,3 @@
+### Summary
+
+### Test Plan

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+
+
+# local Git Template override for Graphite
+.github/PULL_REQUEST_TEMPLATE/99_user_template.md


### PR DESCRIPTION
### Summary

Adds a PR Template setup. The default template is empty to avoid
conflicting with people's pre-written commit messages and a default
other template exists. Additionally, we support adding a
user-customized template at
`.github/PULL_REQUEST_TEMPLATE/99_user_template.md` which allows users
to have their own defaults.

### Test Plan

- When submitting this PR, I was asked to select a template
