### PR TITLE
Update gdb-xtensa-esp32-elf to 17.1

### DIFF
--- a/gdb-xtensa-esp32-elf/conda_build_config.yaml
+++ b/gdb-xtensa-esp32-elf/conda_build_config.yaml
@@ -1,62 +1,95 @@
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
+  - vs2022                     # [win]
+# Please remember to update gcc_compiler_version & clang_compiler_version too.
 c_compiler_version:            # [unix]
-  - 12                         # [linux]
-  - 16                         # [osx]
-  - 7                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 9                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
+  - 14                         # [linux and not riscv64]
+  - 15                         # [linux and riscv64]
+  - 19                         # [osx]
+  - 14                         # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+c_stdlib:
+  - sysroot                    # [linux]
+  - macosx_deployment_target   # [osx]
+  - vs                         # [win]
+m2w64_c_stdlib:                # [win]
+  - m2w64-sysroot              # [win]
+m2w64_c_stdlib_version:        # [win]
+  - 12                         # [win]
+c_stdlib_version:              # [unix]
+  - 2.17                       # [linux and not riscv64]
+  - 2.39                       # [linux and riscv64]
+  - 2.17                       # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 11.0                       # [osx]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
-  - vs2019                     # [win and x86_64]
-  - vs2022                     # [win and arm64]
+  - vs2022                     # [win]
+# Please remember to update gxx_compiler_version & clangxx_compiler_version too.
 cxx_compiler_version:          # [unix]
-  - 12                         # [linux]
-  - 16                         # [osx]
-  - 7                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 9                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
+  - 14                         # [linux and not riscv64]
+  - 15                         # [linux and riscv64]
+  - 19                         # [osx]
+  - 14                         # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 llvm_openmp:                   # [osx]
-  - 16                         # [osx]
+  - 19                         # [osx]
 fortran_compiler:              # [unix or win64]
-  - gfortran                   # [linux64 or (osx and x86_64)]
-  - gfortran                   # [aarch64 or ppc64le or armv7l or s390x]
+  - gfortran                   # [unix]
   - flang                      # [win64]
 fortran_compiler_version:      # [unix or win64]
-  - 12                         # [linux]
-  - 12                         # [osx]
+  - 14                         # [linux and not riscv64]
+  - 15                         # [linux and riscv64]
+  - 14                         # [osx]
   - 5                          # [win64]
-  - 7                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 9                          # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
-  - 10                         # [os.environ.get("CF_CUDA_ENABLED", "False") == "True" and linux64]
+  - 14                         # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+m2w64_c_compiler:                 # [win]
+  - gcc                           # [win]
+m2w64_c_compiler_version:         # [win]
+  - 14                            # [win]
+m2w64_cxx_compiler:               # [win]
+  - gxx                           # [win]
+m2w64_cxx_compiler_version:       # [win]
+  - 14                            # [win]
+m2w64_fortran_compiler:           # [win]
+  - gfortran                      # [win]
+m2w64_fortran_compiler_version:   # [win]
+  - 14                            # [win]
+
+# enable `{{ compiler("gcc") }}`, `{{ compiler("clang") }}` & co.
+gcc_compiler:
+  - gcc
+gcc_compiler_version:
+  - 14  # [not osx]
+  - 15  # [osx]
+gxx_compiler:
+  - gxx
+gxx_compiler_version:
+  - 14  # [not osx]
+  - 15  # [osx]
+clang_compiler:
+  - clang     # [unix]
+  # stay compatible with MSVC
+  - clang-cl  # [win]
+clang_compiler_version:
+  - 19
+clangxx_compiler:
+  - clangxx   # [unix]
+  # stay compatible with MSVC
+  - clang-cl  # [win]
+clangxx_compiler_version:
+  - 19
 
 cuda_compiler:
-  - None
-  - nvcc                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - nvcc                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - nvcc                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - nvcc                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - cuda-nvcc
 cuda_compiler_version:
   - None
-  - 10.2                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 11.0                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 11.1                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 11.2                       # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 12.9                       # [((linux and not ppc64le) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 cuda_compiler_version_min:
-  - None                       # [osx]
-  - 10.2                       # [linux64 or win64]
-  - 11.2                       # [linux and (ppc64le or aarch64)]
-cudnn:
-  - undefined
-  - 7                          # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 8                          # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 8                          # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 8                          # [(linux64 or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - None                       # [osx or ppc64le]
+  - 12.9                       # [(linux and not ppc64le) or win64]
+
+arm_variant_type:              # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - sbsa                       # [aarch64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 _libgcc_mutex:
   - 0.1 conda_forge
@@ -82,94 +115,82 @@ cgo_compiler:
 target_goos:
   - linux                      # [linux]
   - darwin                     # [osx]
+  - windows                    # [win]
 target_goarch:
   - amd64                      # [x86_64]
   - arm64                      # [arm64 or aarch64]
   - ppc64le                    # [ppc64le]
 target_goexe:
   -                            # [unix]
+  - .exe                       # [win]
 target_gobin:
   - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]
 
 # Rust Compiler Options
 rust_compiler:
   - rust
 
+# the numbers here are the Darwin Kernel version for macOS 10.9 & 11.0;
+# this is used to form our target triple on osx, and nothing else. After
+# we bumped the minimum macOS version to 10.13, this was left unchanged,
+# since it is not essential, and long-term we'd like to remove the version.
 macos_machine:                 # [osx]
+  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
   - arm64-apple-darwin20.0.0   # [osx and arm64]
-MACOSX_DEPLOYMENT_TARGET:      # [osx]
-  - 11.0                       # [osx and arm64]
+
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:
   - VERBOSE=1
 
-# dual build configuration
 channel_sources:
-  - conda-forge                                 # [not s390x]
-  - https://conda-web.anaconda.org/conda-forge  # [s390x]
+  - conda-forge
 
 channel_targets:
   - conda-forge main
 
 cdt_name:  # [linux]
-  - cos6   # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos6"]
-  - cos7   # [linux64 and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos7"]
-  - cos7   # [linux and aarch64]
-  - cos7   # [linux and ppc64le]
-  - cos7   # [linux and armv7l]
-  - cos7   # [linux and s390x]
+  - conda  # [linux]
 
-  - cos6   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos6"]
-  - cos7   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("DEFAULT_LINUX_VERSION", "cos6") == "cos7"]
-  - cos7   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - cos7   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - cos7   # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+docker_image:                                       # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
+  # builds on CentOS 7
+  - quay.io/condaforge/linux-anvil-x86_64:cos7      # [os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "cos7"]
+  - quay.io/condaforge/linux-anvil-aarch64:cos7     # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "cos7"]
+  - quay.io/condaforge/linux-anvil-ppc64le:cos7     # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "cos7"]
 
-docker_image:                                   # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
-  - quay.io/condaforge/linux-anvil-cos7-x86_64  # [os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - quay.io/condaforge/linux-anvil-aarch64      # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
-  - quay.io/condaforge/linux-anvil-ppc64le      # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
-  - quay.io/condaforge/linux-anvil-armv7l       # [os.environ.get("BUILD_PLATFORM") == "linux-armv7l"]
+  # builds on AlmaLinux 8
+  - quay.io/condaforge/linux-anvil-x86_64:alma8     # [os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") in ("alma8", "ubi8")]
+  - quay.io/condaforge/linux-anvil-aarch64:alma8    # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") in ("alma8", "ubi8")]
+  - quay.io/condaforge/linux-anvil-ppc64le:alma8    # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") in ("alma8", "ubi8")]
 
-  - quay.io/condaforge/linux-anvil-cos7-cuda:10.2  # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - quay.io/condaforge/linux-anvil-cuda:11.0       # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - quay.io/condaforge/linux-anvil-cuda:11.1       # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - quay.io/condaforge/linux-anvil-cuda:11.2       # [linux64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  # builds on AlmaLinux 9
+  - quay.io/condaforge/linux-anvil-x86_64:alma9     # [os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "alma9"]
+  - quay.io/condaforge/linux-anvil-aarch64:alma9    # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "alma9"]
+  - quay.io/condaforge/linux-anvil-ppc64le:alma9    # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "alma9"]
+
+  # builds on AlmaLinux 10
+  - quay.io/condaforge/linux-anvil-x86_64:alma10    # [os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "alma10"]
+  - quay.io/condaforge/linux-anvil-aarch64:alma10   # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "alma10"]
+  - quay.io/condaforge/linux-anvil-ppc64le:alma10   # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma10") == "alma10"]
 
 zip_keys:
   -                             # [unix]
     - c_compiler_version        # [unix]
     - cxx_compiler_version      # [unix]
     - fortran_compiler_version  # [unix]
-    - cudnn                     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - cuda_compiler             # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+    # CUDA 13.x requires newer glibc than our current baseline
+    - c_stdlib_version          # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
     - cuda_compiler_version     # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - cdt_name                  # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - docker_image              # [linux and os.environ.get("CF_CUDA_ENABLED", "False") == "True" and os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
-  -                             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - cudnn                     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - cuda_compiler             # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-    - cuda_compiler_version     # [win64 and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   -
     - python
-    - numpy
-    - python_impl
-  # transition until arrow_cpp can be dropped for arrow 13.x
+    - is_python_min
   -
-    - arrow_cpp
     - libarrow
-  # until libprotobuf 3.21->4.23 migration is complete
+    - libarrow_all
   -
-    - libgrpc
-    - libprotobuf
-
-
-# aarch64 specifics because conda-build sets many things to centos 6
-# this can probably be removed when conda-build gets updated defaults
-# for aarch64
-cdt_arch: aarch64                       # [aarch64]
-BUILD: aarch64-conda_cos7-linux-gnu     # [aarch64]
+    - root_base
+    - root_cxx_standard
 
 # armv7l specifics because conda-build sets many things to centos 6
 # this can probably be removed when conda-build gets updated defaults
@@ -178,27 +199,10 @@ cdt_arch: armv7l                          # [armv7l]
 BUILD: armv7-conda_cos7-linux-gnueabihf   # [armv7l]
 
 pin_run_as_build:
-  # boost is special, see https://github.com/conda-forge/boost-cpp-feedstock/pull/82
-  boost:
-    max_pin: x.x.x
-  boost-cpp:
-    max_pin: x.x.x
-  # TODO: add run_exports to the following feedstocks
-  flann:
-    max_pin: x.x.x
-  graphviz:
-    max_pin: x
-  libsvm:
-    max_pin: x
+  libblst:
+    max_pin: x.x
   netcdf-cxx4:
     max_pin: x.x
-  occt:
-    max_pin: x.x
-  poppler:
-    max_pin: x.x
-  r-base:
-    max_pin: x.x
-    min_pin: x.x
   vlfeat:
     max_pin: x.x.x
 
@@ -206,85 +210,100 @@ pin_run_as_build:
 
 # blas
 libblas:
-  - 3.9 *netlib
+  - 3.9.* *netlib
 libcblas:
-  - 3.9 *netlib
+  - 3.9.* *netlib
 liblapack:
-  - 3.9 *netlib
+  - 3.9.* *netlib
 liblapacke:
-  - 3.9 *netlib
+  - 3.9.* *netlib
 blas_impl:
   - openblas
   - mkl          # [x86 or x86_64]
   - blis         # [x86 or x86_64]
 
-# this output was dropped as of libabseil 20230125
-abseil_cpp:
-  - '20220623.0'
+ace:
+  - 8.0.6
 alsa_lib:
-  - 1.2.8
+  - '1.2'
 antic:
   - 0.2
 aom:
-  - 3.5
+  - '3.14'
 arb:
   - '2.23'
 arpack:
-  - 3.7
-# keep in sync with libarrow
-arrow_cpp:
-  - 12
-  - 11.0.0
-  - 10.0.1
-  - 9.0.0
+  - '3.9'
 assimp:
-  - 5.2.5
+  - 6
 attr:
   - 2.5
 aws_c_auth:
-  - 0.7.0
+  - '0.10.4'
 aws_c_cal:
-  - 0.6.0
+  - '0.9.14'
 aws_c_common:
-  - 0.8.23
-# coupled to aws_c_common version bump, see
-# https://github.com/conda-forge/aws-c-http-feedstock/pull/109
+  - '0.14.2'
+aws_c_compression:
+  - '0.3.2'
 aws_c_event_stream:
-  - 0.3.1
+  - '0.7.1'
 aws_c_http:
-  - 0.7.10
-# the builds got coupled because 0.2.4 landed before the this migrator finished
+  - '0.11.0'
 aws_c_io:
-  - 0.13.28
-# the builds got coupled because 0.2.4 landed before the io migrator
+  - '0.27.3'
 aws_c_mqtt:
-  - 0.8.14
+  - '0.16.0'
 aws_c_s3:
-  - 0.3.13
+  - '0.12.8'
 aws_c_sdkutils:
-  - 0.1.11
+  - '0.2.7'
 aws_checksums:
-  - 0.1.16
+  - '0.2.10'
 aws_crt_cpp:
-  - 0.20.3
+  - '0.40.1'
 aws_sdk_cpp:
-  - 1.10.57
-boost:
-  - 1.78.0
-boost_cpp:
-  - 1.78.0
+  - 1.11.833
+azure_core_cpp:
+  - 1.16.3
+azure_identity_cpp:
+  - 1.13.3
+azure_storage_blobs_cpp:
+  - 12.18.0
+azure_storage_common_cpp:
+  - 12.14.0
+azure_storage_files_datalake_cpp:
+  - 12.16.0
+azure_storage_files_shares_cpp:
+  - 12.18.0
+azure_storage_queues_cpp:
+  - 12.7.0
+brotli:
+  - '1.2'
+bullet_cpp:
+  - 3.25
+bxdecay0:
+  - '1.2.0'
 bzip2:
   - 1
 c_ares:
   - 1
+c_blosc2:
+  - '3.3'
 cairo:
   - 1
+calchep:
+  - '3.8'
 capnproto:
-  - 0.10.2
+  - 1.5.0
+casadi:
+  - 3.7
 ccr:
   - 1.3
 cfitsio:
-  - 4.1.0
+  - 4.6.3
+cmocka:
+  - 2.0.1
 coin_or_cbc:
   - 2.10
 coincbc:
@@ -297,12 +316,19 @@ coin_or_osi:
   - 0.108
 coin_or_utils:
   - 2.11
+collier:
+  - '1.2'
 console_bridge:
   - 1.0
+# match with libcudnn-dev
+cudnn:
+  - '9'
 cutensor:
-  - 1
+  - 2
 curl:
   - 8
+dartsim_cpp:
+  - '6.19'
 dav1d:
   - 1.2.1
 davix:
@@ -311,266 +337,526 @@ dbus:
   - 1
 dcap:
   - 2.47
+delphes:
+  - '3.5.1'
 eclib:
-  - '20230424'
+  - '20250627'
+eigen_abi_devel:
+  - '5.0.1'
 elfutils:
   - 0.189.memfault2
+emela:
+  - '1.0'
 exiv2:
-  - 0.27
+  - '0.28'
 expat:
   - 2
+fastbdt:
+  - '5.6'
+fastjet_contrib:
+  - '1'
+fastjet_cxx:
+  - '3.5'
+feynhiggs:
+  - '2.19'
 ffmpeg:
-  - '6'
+  - '8'
 fftw:
   - 3
 flann:
-  - 1.9.1
+  - 1.9.2
 flatbuffers:
-  - 23.5.26
+  - 25.9.23
 fmt:
-  - '9'
+  - '12.1'
 fontconfig:
   - 2
 freetype:
   - 2
+gaudi:
+  - '40.4'
 gct:
-  - 6.2.1629922860
+  - 6.2.1705709074
 gf2x:
   - '1.3'
 gdk_pixbuf:
   - 2
 gnuradio_core:
-  - 3.10.6
+  - 3.10.12
 gnutls:
-  - 3.7
+  - '3.8'
 gsl:
   - 2.7
 gsoap:
   - 2.8.123
 gstreamer:
-  - '1.22'
+  - '1.26'
 gst_plugins_base:
-  - '1.22'
+  - '1.26'
 gdal:
-  - '3.6'
+  - '3.12'
+libgdal:
+  - '3.12'
+libgdal_core:
+  - '3.12'
+geant4:
+  - 11.4.2
 geos:
-  - 3.11.2
+  - 3.14.1
 geotiff:
-  - 1.7.1
+  - '1.7'
 gfal2:
-  - '2.21'
+  - '2.23'
 gflags:
-  - 2.2
+  - '2.3'
 giflib:
   - 5.2
+givaro:
+  - '4.2.1'
 glew:
-  - 2.1
+  - '2.3'
 glib:
   - '2'
 glog:
-  - '0.6'
+  - '0.7'
 glpk:
   - '5.0'
+gm2calc:
+  - '2.3'
 gmp:
   - 6
-# keep google_cloud_cpp in sync with libgoogle_cloud
 google_cloud_cpp:
-  - '2.12'
+  - '3.7'
 google_cloud_cpp_common:
   - 0.25.0
 googleapis_cpp:
   - '0.10'
+gpgme:
+  - '1.24'
 graphviz:
-  - '8'
-# this has been renamed to libgrpc as of 1.49; dropped as of 1.52.
-# IOW, this version is unavailable; makes the renaming more obvious
-grpc_cpp:
-  - '1.52'
-harfbuzz:
-  - '6'
+  - '14'
+# Harfbuzz guarantees total ABI compatibiblity
+# The first version to have this new ABI pin is 11.0.1
+# https://github.com/conda-forge/harfbuzz-feedstock/pull/125
+# But as of 2025/08/03, 11.0.1 is quite "old" and it is pretty safe
+# to release the pin
+# We are leaving this comment here to discourage others from adding
+# a harfbuzz global pin, as it is not needed.
+# harfbuzz:
+# - '11'
+hepmc2:
+  - '2.06'
+hepmc3:
+  - '3.3'
 hdf4:
   - 4.2.15
 hdf5:
-  - 1.12.2
+  - 1.14.6
+hdrhistogram_c:
+  - 0.11.9
 icu:
-  - '70'
+  - '75'
+idyntree:
+  - '15'
 imath:
-  - 3.1.9
+  - 3.2.2
+impi_devel:
+  - "2021.16.0"
 ipopt:
-  - 3.14.12
+  - 3.14.19
 isl:
-  - '0.25'
+  - '0.26'
 jasper:
   - 4
 jpeg:
   - 9
-lcms:
+lcms2:
   - 2
 lerc:
   - '4'
+lhapdf:
+  - '6.5'
 libjpeg_turbo:
-  - 2
+  - '3'
+libjxl:
+  - '0.12'
 libev:
   - 4.33
 json_c:
-  - '0.16'
+  - '0.18'
 jsoncpp:
-  - 1.9.5
+  - 1.9.7
 kealib:
-  - '1.5'
+  - '2.0'
 krb5:
-  - '1.19'
+  - '1.22'
+ldas_tools_framecpp:
+  - '2.9'
 libabseil:
-  - '20230125'
-libabseil_static:
-  - '20220623.0'
+  - 20260107
 libaec:
   - '1'
+libamd:
+  - '3'
 libarchive:
-  - '3.6'
-# keep in sync with arrow_cpp (libarrow exists only from 10.x,
-# but make sure we have same length for zip as arrow_cpp)
+  - '3.8'
 libarrow:
-  - 12
-  - 11.0.0
-  - 10.0.1
-  - 9.0.0
+  - '25.0'
+  - '24.0'
+  - '23.0'
+  - '22.0'
+libarrow_all:
+  - '25.0'
+  - '24.0'
+  - '23.0'
+  - '22.0'
+libattr:
+  - 2.6
 libavif:
-  - 0.11.1
+  - 1
 libblitz:
   - 1.0.2
+libblst:
+  - '0.3'
+libboost_devel:
+  - "1.88"
+libboost_headers:
+  - "1.88"
+libboost_python_devel:
+  - "1.88"
+libbrotlicommon:
+  - '1.2'
+libbrotlidec:
+  - '1.2'
+libbrotlienc:
+  - '1.2'
+libbtf:
+  - '2'
+libcamd:
+  - '3'
+libcap:
+  - '2.78'
 libcint:
-  - '5.2'
+  - '6.1'
+libccolamd:
+  - '3'
+libcholmod:
+  - '5'
+libcolamd:
+  - '3'
 libcurl:
   - 8
+# match with cudnn
+libcudnn_dev:
+  - '9'
 libcrc32c:
   - 1.1
+libcxsparse:
+  - '4'
 libdap4:
   - 3.20.6
 libdeflate:
-  - '1.18'
+  - '1.25'
+libdovi:
+  - '3'
+libduckdb_devel:
+  - '1'
 libeantic:
-  - 1
+  - '2'
 libevent:
   - 2.1.12
 libexactreal:
-  - '3'
+  - '4'
 libffi:
-  - '3.4'
+  - '3.5'
+libflac:
+  - '1.5'
 libflatsurf:
   - 3
 libflint:
-  - '2.9'
-libgdal:
-  - '3.6'
+  - '3.3'
+libframel:
+  - '8.41'
+# hmaarrfk - Aug 30, 2025
+# https://github.com/conda-forge/libfuse-feedstock/pull/29
+# Although some libfuse packages exist with version 3, we decided
+# to pin libfuse to 2 to allow co-installation between libfuse (version 2) and libfuse3
+libfuse:
+  - '2'
+libfuse3:
+  - '3'
 libgit2:
-  - '1.6'
-# Keep in sync with google_cloud_cpp
+  - '1.9'
 libgoogle_cloud:
-  - '2.12'
+  - '3.7'
+libgoogle_cloud_devel:
+  - '3.7'
+libgoogle_cloud_all_devel:
+  - '3.7'
+libgoogle_cloud_aiplatform_devel:
+  - '3.7'
+libgoogle_cloud_automl_devel:
+  - '3.7'
+libgoogle_cloud_bigquery_devel:
+  - '3.7'
+libgoogle_cloud_bigtable_devel:
+  - '3.7'
+libgoogle_cloud_compute_devel:
+  - '3.7'
+libgoogle_cloud_dialogflow_cx_devel:
+  - '3.7'
+libgoogle_cloud_dialogflow_es_devel:
+  - '3.7'
+libgoogle_cloud_discoveryengine_devel:
+  - '3.7'
+libgoogle_cloud_dlp_devel:
+  - '3.7'
+libgoogle_cloud_iam_devel:
+  - '3.7'
+libgoogle_cloud_oauth2_devel:
+  - '3.7'
+libgoogle_cloud_policytroubleshooter_devel:
+  - '3.7'
+libgoogle_cloud_pubsub_devel:
+  - '3.7'
+libgoogle_cloud_spanner_devel:
+  - '3.7'
+libgoogle_cloud_speech_devel:
+  - '3.7'
+libgoogle_cloud_storage_devel:
+  - '3.7'
 libgrpc:
-  - '1.52'
+  - "1.78"
+libgsasl:
+  - '2'
+libheif:
+  - '1.23'
 libhugetlbfs:
   - 2
+libhwloc:
+  - 2.13.0
 libhwy:
-  - '1.0'
+  - '1.4'
 libiconv:
   - 1
 libidn2:
   - 2
 libintervalxt:
   - 3
+libitk_devel:
+  - 5.4
+libklu:
+  - '2'
 libkml:
   - 1.3
+libkml_devel:
+  - 1.3
+liblzma_devel:
+  - 5
 libiio:
   - 0
+libldl:
+  - '3'
+libmagma:
+  - '2.10.0'
+libmagma_devel:
+  - '2.10.0'
+libmagma_sparse:
+  - '2.10.0'
+libmed:
+  - '4.2'
 libmatio:
-  - 1.5.21
+  - 1.5.30
+libmatio_cpp:
+  - 0.3.0
 libmicrohttpd:
-  - 0.9
+  - '1.0'
 libnetcdf:
-  - 4.8.1
+  - 4.10.0
+libntlm:
+  - 1
+libode:
+  - 0.16.6
+libogg:
+  - 1.3
+libopencolorio:
+  - '2.5'
+libopenimageio:
+  - '3.1'
 libopencv:
-  - 4.7.0
+  - 4.13.0
+libopentelemetry_cpp:
+  - '1.27'
 libosqp:
-  - 0.6.3
+  - 1.0.0
+libopenvino:
+  - '2026.2.1'
+libopenvino_dev:
+  - '2026.2.1'
+libparu:
+  - '1'
 libpcap:
   - '1.10'
+libplacebo:
+  - '7.360'
+libpnetcdf:
+  - 1.15.0
 libpng:
   - 1.6
 libprotobuf:
-  - '3.21'
+  - 6.33.5
 libpq:
-  - 15
+  - '18'
+libpsl:
+  - '0.23'
+libpulsar:
+  - 4.2.0
+libraqm:
+  - '0.11'
+libraqm_devel:
+  - '0.11'
 libraw:
-  - '0.21'
+  - '0.22'
+librbio:
+  - '4'
 librdkafka:
-  - '1.9'
+  - '2.14'
+librdkit:
+  - 2026.03.2
+librealsense:
+  - '2.58'
+librerun_sdk:
+  - 0.32.2
 librsvg:
   - 2
 libsecret:
-  - 0.18
+  - '0.21'
 libsentencepiece:
-  - '0.1.99'
+  - 0.2.1
 libsndfile:
   - '1.2'
+libsodium:
+  - 1.0.22
+libsoup:
+  - 3
 libspatialindex:
-  - 1.9.3
+  - 2.1.0
+libspex:
+  - '3'
+libspqr:
+  - '4'
+libsuitesparseconfig:
+  - '7'
+libsuperiso:
+  - '5.0'
 libssh:
-  - 0.10
+  - '0.12'
 libssh2:
   - 1
 libsvm:
-  - '325'
-# keep libsqlite in sync with sqlite
+  - '337'
 libsqlite:
   - 3
+libsystemd:
+  - '257'
+libtensorflow:
+  - "2.16"
+libtensorflow_cc:
+  - "2.16"
+libtheora:
+  - '1.2'
 libthrift:
-  - 0.18.1
+  - 0.22.0
 libtiff:
-  - 4.4
+  - '4.7'
+libtorch:
+  - '2.11'
+libudev:
+  - '257'
+libumfpack:
+  - '6'
 libunwind:
-  - '1.6'
+  - '1.8'
+libutf8proc:
+  - '2.11'
 libv8:
   - 8.9.83
+libvigra:
+  - '1.12'
 libvips:
   - 8
+libvpl:
+  - '2.16'
 libwebp:
   - 1
 libwebp_base:
   - 1
+libx86emu:
+  - 3.7
+libxcb:
+  - '1'
 libxml2:
-  - 2.10
+  - '2.14'
+libxml2_devel:
+  - '2.14'
+libxrootd_devel:
+  - '6'
 libxsmm:
-  - 1
+  - '2'
+liburing:
+  - 2.14
 libuuid:
   - 2
+libyarp:
+  - 3.12.2
 libzip:
   - 1
+lmdb:
+  - 0.9.29
 log4cxx:
-  - 0.11.0
+  - 1.2.0
+lol_html:
+  - 3.0.1
+ls_hpack:
+  - 2.3.5
+lwtnn:
+  - '2.14'
 lz4_c:
-  - '1.9.3'
+  - '1.10'
 lzo:
   - 2
+magma:
+  - '2.9'
 metis:
-  - 5.1
+  - 5.1.0
 mimalloc:
-  - 2.1.1
+  - 3.4.1
 mkl:
-  - 2022
+  - '2026'  # [not osx]
+  - '2023'  # [osx]
 mkl_devel:
-  - 2022
+  - '2026'  # [not osx]
+  - '2023'  # [osx]
 mpg123:
-  - '1.31'
+  - '1.32'
 mpich:
   - 4
 mpfr:
   - 4
+mpfun90:
+  - '2026'
+mppp:
+  - '2.0'
+msgpack_c:
+  - 6
+msgpack_cxx:
+  - '7'
 mumps_mpi:
-  - 5.2.1
+  - 5.8.2
 mumps_seq:
-  - 5.2.1
+  - 5.8.2
+mysql_devel:
+  - '9.7'
 nccl:
   - 2
 ncurses:
@@ -578,135 +864,199 @@ ncurses:
 netcdf_cxx4:
   - 4.3
 netcdf_fortran:
-  - 4.5
+  - '4.6'
 nettle:
-  - '3.8'
+  - '3.10'
+ninja_hep_ph:
+  - '1.2'
 nodejs:
-  - '18'
-  - '16'
+  - '26'
+  - '24'
 nss:
   - 3
 nspr:
   - 4
 nlopt:
-  - '2.7'
+  - '2.11'
 ntl:
-  - '11.4.3'
-# we build for the oldest version possible of numpy for forward compatibility
+  - 11.6.0
+# we build using the latest minor version; numpy has generous backwards compatibility
+# even so, and this is reflected through the run-exports of the package; see also
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/4816
 numpy:
-  # part of a zip_keys: python, python_impl, numpy
-  - 1.22
-  - 1.23
-  - 1.26
-  - 1.26
-  - 1.26
+  - 2
+obake_devel:
+  - '0.9'
 occt:
-  - '7.7'
+  - 7.9.3
+oneloop:
+  - '3.7'
 openblas:
   - 0.3.*
 openexr:
-  - '3.1'
+  - '3.4'
 openh264:
-  - '2.3.1'
+  - 2.6.0
 openjpeg:
   - '2'
+openjph:
+  - '0.31'
 openmpi:
   - 4
+openslide:
+  - 4
+# although openssl follows SemVer for ABI/API stability, we stay on
+# LTS version at build time to avoid forcing newer version at runtime
 openssl:
-  - '3'
-openturns:
-  - '1.20'
+  - '3.5'
 orc:
-  - 1.8.4
+  - 2.3.1
+osqp_eigen:
+  - '0.11'
 pango:
-  - 1.50
+  - '1'
 pari:
-  - 2.15.* *_pthread
+  - 2.17.* *_pthread
 pcl:
-  - 1.13.0
+  - 1.15.1
 perl:
   - 5.32.1
 petsc:
-  - '3.18'
+  - '3.25'
 petsc4py:
-  - '3.18'
+  - '3.25'
+plutovg:
+  - 1.3.3
+plutosvg:
+  - 0.0.8
+pugixml:
+  - '1.15'
 slepc:
-  - '3.18'
+  - '3.25'
 slepc4py:
-  - '3.18'
+  - '3.25'
 svt_av1:
-  - 1.6.0
+  - 4.2.0
 p11_kit:
-  - '0.24'
+  - '0.26'
 pcre:
   - '8'
 pcre2:
-  - '10.40'
+  - '10.47'
+pdal:
+  - '2.10'
+libpdal:
+  - '2.10'
+libpdal_core:
+  - '2.10'
 pixman:
   - 0
 poco:
-  - 1.12.4
+  - 1.15.3
 poppler:
-  - '22.12'
+  - '26.07'
+portaudio:
+  - '19.7'
 postgresql:
-  - 15
+  - '18'
 postgresql_plpython:
-  - 15
+  - '18'
 proj:
-  - 9.2.0
+  - '9.8'
 pulseaudio:
-  - '16.1'
+  - '17.0'
+pulseaudio_client:
+  - '17.0'
+pulseaudio_daemon:
+  - '17.0'
 pybind11_abi:
   - 4
+pythia8:
+  - '8.312'
 python:
-  # part of a zip_keys: python, python_impl, numpy
+  # part of a zip_keys: python, is_python_min
   - 3.10.* *_cpython
-  - 3.11.* *_cpython
   - 3.12.* *_cpython
   - 3.13.* *_cp313
   - 3.14.* *_cp314
 python_impl:
-  # part of a zip_keys: python, python_impl, numpy
   - cpython
-  - cpython
-  - cpython
-  - cpython
-  - cpython
+python_min:
+  # minimum supported python version per CFEP-25
+  - '3.10'
+is_freethreading:
+  - false
+is_python_min:
+  # part of a zip_keys: python, is_python_min
+  - true
+  - false
+  - false
+  - false
+is_abi3:
+  - true
 pytorch:
-  - '2.0'
+  - '2.11'
 pyqt:
   - 5.15
 pyqtwebengine:
   - 5.15
 pyqtchart:
   - 5.15
+qcdloop:
+  - '2.1'
+qhull:
+  - 2020.2
+qpdf:
+  - '12'
 qt:
   - 5.15
 qt_main:
   - 5.15
 qt6_main:
-  - '6.5'
+  - '6'
 qtkeychain:
-  - '0.14'
+  - '0.16'
+rav1e:
+  - '0.8'
+rdma_core:
+  - '63'
 re2:
-  - 2023.03.02
+  - 2025.11.05
 readline:
   - "8"
+rivet:
+  - '4.1'
 rocksdb:
-  - "6.10"
+  - '11.0'
 root_base:
-  - 6.26.10
-ruby:
-  - 2.5
-  - 2.6
+  - 6.36.10
+  - 6.38.4
+  - 6.38.4
+  - 6.40.2
+  - 6.40.2
+root_cxx_standard:
+  - 20
+  - 20
+  - 23
+  - 20
+  - 23
 r_base:
-  - 4.2   # [not win]
+  - 4.4
+  - 4.5
+libscotch:
+  - 7.0.11
+libptscotch:
+  - 7.0.11
 scotch:
-  - 6.0.9
+  - 7.0.11
 ptscotch:
-  - 6.0.9
+  - 7.0.11
+s2geography:
+  - 0.1.2
+s2geometry:
+  - '0.14'
 s2n:
-  - 1.3.46
+  - 1.7.6
 sdl2:
   - '2'
 sdl2_image:
@@ -717,72 +1067,105 @@ sdl2_net:
   - '2'
 sdl2_ttf:
   - '2'
+shaderc:
+  - '2026.3'
+sherpa:
+  - '3.0'
 singular:
-  - 4.2.1.p3
+  - 4.4.1
+siscone:
+  - '3.1'
 snappy:
-  - 1
+  - 1.2
 soapysdr:
   - '0.8'
+softsusy:
+  - '4.1'
 sox:
   - 14.4.2
 spdlog:
-  - '1.11'
-# keep sqlite in sync with libsqlite
+  - '1.17'
+spirv_tools:
+  - '2026'
 sqlite:
   - 3
 srm_ifce:
   - 1.24.6
 starlink_ast:
-  - '9.2.7'
+  - 9.3.1
 suitesparse:
-  - 5
+  - '7'
+suitesparse_mongoose:
+  - '3'
+sundials:
+  - '7.7'
 superlu_dist:
-  - 7.1.1
+  - '9'
+swig_abi:
+  - '5'
 tbb:
-  - '2021'
+  - '2023'
 tbb_devel:
-  - '2021'
+  - '2023'
+tensorflow:
+  - "2.16"
 thrift_cpp:
-  - 0.18.1
+  - 0.22.0
 tinyxml2:
-  - 9
+  - '11.0'
 tk:
   - 8.6                # [not ppc64le]
 tiledb:
-  - '2.13'
+  - '2.30'
+ucc:
+  - 1
 ucx:
-  - 1.14.0
+  - '1.22'
 uhd:
-  - 4.4.0
+  - 4.10.0
 urdfdom:
-  - 3.1
+  - '5.1'
+vc:                    # [win]
+  - 14                 # [win]
+vgm:
+  - '5.4'
+vigra:
+  - '1.12'
 vlfeat:
   - 0.9.21
+vmc:
+  - '2.2'
 volk:
-  - '3.0'
+  - '3.3'
 vtk:
-  - 9.2.5
+  - 9.6.2
+vtk_base:
+  - 9.6.2
 wcslib:
-  - '7'
+  - '8'
 wxwidgets:
-  - '3.2'
+  - 3.3.3
 x264:
   - '1!164.*'
 x265:
   - '3.5'
 xerces_c:
-  - 3.2
+  - '3.3'
 xrootd:
-  - '5'
+  - '6'
+xxhash:
+  - 0.8.3
 xz:
   - 5
+yoda:
+  - '2.1'
 zeromq:
-  - 4.3.4
+  - '4.3.5'
 zfp:
   - 1.0
 zlib:
-  - 1.3
+  - 1
 zlib_ng:
-  - 2.0
+  - '2.3'
 zstd:
   - '1.5'

--- a/gdb-xtensa-esp32-elf/meta.yaml
+++ b/gdb-xtensa-esp32-elf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xtensa-esp32-elf-gdb" %}
-{% set version = "16.3_20250913" %}
+{% set version = "17.1_20260402" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Latest release from espressif.

Update build matrix for only python 3.10, 3.12, 3.13, 3.14
