### PR TITLE
chore(conda): update overmind to 2.5.1 to update tmux

### DIFF
--- a/overmind/meta.yaml
+++ b/overmind/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "overmind" %}
-{% set version = "2.4.0" %}
+{% set version = "2.5.1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  # > (OVERMIND_VER=2.4.0; for _arch in macos-amd64 macos-arm64 linux-arm64; do curl -sSL https://github.com/DarthSim/overmind/releases/download/v${OVERMIND_VER}/overmind-v${OVERMIND_VER}-${_arch}.gz | sha256sum; done)
+  # > (OVERMIND_VER=2.5.1; for _arch in macos-amd64 macos-arm64 linux-amd64; do curl -sSL https://github.com/DarthSim/overmind/releases/download/v${OVERMIND_VER}/overmind-v${OVERMIND_VER}-${_arch}.gz | sha256sum; done)
   url: https://github.com/DarthSim/overmind/releases/download/v{{ version }}/overmind-v{{ version}}-macos-amd64.gz    # [osx and x86_64]
-  sha256: d0258dba536dad639cd52be4f1a3fb5143cf6d550d1830853ed6dcaaa886a399                                            # [osx and x86_64]
+  sha256: 58cc613d08bcb9b6c92b8b70e815d5dbb2ab9a30cfa6aa295ea796dc46ef1361                                            # [osx and x86_64]
   url: https://github.com/DarthSim/overmind/releases/download/v{{ version }}/overmind-v{{ version }}-macos-arm64.gz   # [osx and arm64]
-  sha256: 6d1e4bd2ce5fa9ca7b3e8d400a7999dcd19cc17b2a4b8f5b8f649e0e91dc33b0                                            # [osx and arm64]
+  sha256: 04aa1dcf64b3d0272b51f49fd300ee346d0bd96e5cfc245121c8d56f2ffaac97                                            # [osx and arm64]
   url: https://github.com/DarthSim/overmind/releases/download/v{{ version }}/overmind-v{{ version }}-linux-amd64.gz   # [linux64]
-  sha256: 1f7cac289b550a71bebf4a29139e58831b39003d9831be59eed3e39a9097311c                                            # [linux64]
+  sha256: a17159b8e97d13f3679a4e8fbc9d4747f82d5af9f6d32597b72821378b5d0b6f                                            # [linux64]
 
 build:
   string: '1'
@@ -20,7 +20,7 @@ build:
 
 requirements:
   run:
-    - tmux 3.5
+    - tmux >=3.6
 
 test:
   commands:


### PR DESCRIPTION
### Issues Addressed

The published `overmind` package pins `tmux 3.4.*`. Since overmind is
the only reason tmux is in our conda env at all, every dev gets a
Feb-2024 tmux. This causes a mismatch if you have a newer tmux server on your
system.

https://github.com/memfault/conda-recipes/pull/91 tried to update
to `tmux 3.5`, but that build was never published. Also 3.6 is out.

### Summary

Update overmind to latest and loosen the dep.

### Test Plan

- Ran overmind 2.4.0 and 2.5.1 against tmux 3.6b and 3.7b; `start -D`,
`status`, `restart`, and `quit` all work on both.
- [x] build with the GH action: https://github.com/memfault/conda-recipes/actions/runs/31518099536
- [x] pushed to anaconda
- [x] test locally with `inv dev` to ensure it works correctly
- [x] create a PR in memfault/memfault to bump this

Resolves: PLAT-X