### PR TITLE
add linux-aarch64 build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       # run all targets to completion, even if one fails
       fail-fast: false
       matrix:
-        platform: [ubuntu-24.04, macos-15-xlarge]
+        platform: [ubuntu-24.04, ubuntu-24.04-arm, macos-15-xlarge]
     runs-on: ${{ matrix.platform }}
 
     # set bash to be a login shell, so that /etc/profile is sourced and conda

--- a/aws-vault/meta.yaml
+++ b/aws-vault/meta.yaml
@@ -8,8 +8,10 @@ package:
 source:
   url: https://github.com/ByteNess/aws-vault/releases/download/v{{ version }}/aws-vault-darwin-arm64 # [osx and arm64]
   sha256: 54c7a2cb4862b239b7795e6442e0853d7ba71c7a8403cdbfd6a76128a797fb00 # [osx and arm64]
-  url: https://github.com/ByteNess/aws-vault/releases/download/v{{ version }}/aws-vault-linux-amd64 # [linux64 and x86_64]
-  sha256: 5917c87f74bacbd4a639830adb75f27c180e75a65ad3d1faef02cf3935c4fd9b # [linux64 and x86_64]
+  url: https://github.com/ByteNess/aws-vault/releases/download/v{{ version }}/aws-vault-linux-amd64 # [linux and x86_64]
+  sha256: 5917c87f74bacbd4a639830adb75f27c180e75a65ad3d1faef02cf3935c4fd9b # [linux and x86_64]
+  url: https://github.com/ByteNess/aws-vault/releases/download/v{{ version }}/aws-vault-linux-arm64 # [linux and aarch64]
+  sha256: c73643cbf1429b9539bbcc1023b834066e0d5c5d7087c27139f3eaf950242431 # [linux and aarch64]
 
 build:
   string: '1'

--- a/clickhouse/build.sh
+++ b/clickhouse/build.sh
@@ -9,7 +9,7 @@ ARCH=$(uname -m)
 # copy the binary into the installation target
 if [ "${OS}" = "Linux" ]; then
 
-  if [ "${ARCH"} = "x86_64" -o "${ARCH}" = "am64" ]; then
+  if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]; then
     UPX_ARCH="amd64"
   elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]; then
     UPX_ARCH="arm64"

--- a/clickhouse/build.sh
+++ b/clickhouse/build.sh
@@ -8,12 +8,19 @@ ARCH=$(uname -m)
 
 # copy the binary into the installation target
 if [ "${OS}" = "Linux" ]; then
+
+  if [ "${ARCH"} = "x86_64" -o "${ARCH}" = "am64" ]; then
+    UPX_ARCH="amd64"
+  elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]; then
+    UPX_ARCH="arm64"
+  fi
+
   cp $SRC_DIR/usr/bin/clickhouse $TARGET_BIN
 
   # the clickhouse binary is like 500MB on linux. let's pack it.
-  wget https://github.com/upx/upx/releases/download/v5.1.1/upx-5.1.1-amd64_linux.tar.xz
-  tar -xf upx-5.1.1-amd64_linux.tar.xz
-  ./upx-5.1.1-amd64_linux/upx $TARGET_BIN
+  wget https://github.com/upx/upx/releases/download/v5.1.1/upx-5.1.1-${UPX_ARCH}_linux.tar.xz
+  tar -xf upx-5.1.1-${UPX_ARCH}_linux.tar.xz
+  ./upx-5.1.1-${UPX_ARCH}_linux/upx $TARGET_BIN
 elif [ "${OS}" = "Darwin" ]; then
   if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]; then
     ARCH_SUFFIX=""

--- a/clickhouse/meta.yaml
+++ b/clickhouse/meta.yaml
@@ -10,8 +10,10 @@ source:
     sha256: a41399e1d0377ec1a356e43a36ccf6e4e970598231ae0c24dc5e4096813a3fe1 # [osx and x86_64]
   - url: https://github.com/ClickHouse/ClickHouse/releases/download/v{{ version }}-stable/clickhouse-macos-aarch64 # [osx and arm64]
     sha256: 3108b8a30a5b2321e4e70a3f7d9ba11f9f3e95d6a5ad5bbdaa1a8471811336cc # [osx and arm64]
-  - url: https://github.com/ClickHouse/ClickHouse/releases/download/v{{ version }}-stable/clickhouse-common-static-{{ version }}-amd64.tgz # [linux64]
-    sha256: e3a02eaa6e28f47ae72f34850e767d91c92dc286212d0bb099bffd9072118f97 # [linux64]
+  - url: https://github.com/ClickHouse/ClickHouse/releases/download/v{{ version }}-stable/clickhouse-common-static-{{ version }}-amd64.tgz # [linux and x86_64]
+    sha256: e3a02eaa6e28f47ae72f34850e767d91c92dc286212d0bb099bffd9072118f97 # [linux and x86_64]
+  - url: https://github.com/ClickHouse/ClickHouse/releases/download/v{{ version }}-stable/clickhouse-common-static-{{ version }}-arm64.tgz # [linux and aarch64]
+    sha256: f958981073e6d46eec07d9494223334bc37dfccad846f1ce1612cf8f299362c0 # [linux and aarch64]
 
 build:
   number: 0

--- a/gdb-multi-arch/conda_build_config.yaml
+++ b/gdb-multi-arch/conda_build_config.yaml
@@ -344,7 +344,7 @@ eclib:
 eigen_abi_devel:
   - '5.0.1'
 elfutils:
-  - 0.189.memfault2
+  - 0.189.memfault3
 emela:
   - '1.0'
 exiv2:

--- a/gdb-xtensa-esp32-elf/build.sh
+++ b/gdb-xtensa-esp32-elf/build.sh
@@ -54,10 +54,22 @@ cp -R "${GDB_DIST}"/lib "$TARGET_PREFIX"/
 
 # Build wrappers
 pushd esp-toolchain-bin-wrappers/gnu-debugger/unix || exit 1
-if [ -z "$MACOSX_DEPLOYMENT_TARGET" ]; then
-  RUST_TARGET_TRIPLET="x86_64-unknown-linux-gnu"
+OS=$(uname -s)
+ARCH=$(uname -m)
+if [ "${OS}" = "Darwin" ]; then
+   RUST_TARGET_TRIPLET="aarch64-apple-darwin"
+elif [ "${OS}" = "Linux" ]; then
+  if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]; then
+    RUST_TARGET_TRIPLET="x86_64-unknown-linux-gnu"
+  elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]; then
+    RUST_TARGET_TRIPLET="aarch64-unknown-linux-gnu"
+  else
+    echo "Unsupported Linux architecture: ${ARCH}" >&2
+    exit 1
+  fi
 else
-  RUST_TARGET_TRIPLET="aarch64-apple-darwin"
+  echo "Unsupported OS: ${OS}" >&2
+  exit 1
 fi
 rustup target add "$RUST_TARGET_TRIPLET"
 cargo install --target=$RUST_TARGET_TRIPLET --no-track --path ./ --root $GDB_DIST

--- a/gdb-xtensa-esp32-elf/conda_build_config.yaml
+++ b/gdb-xtensa-esp32-elf/conda_build_config.yaml
@@ -344,7 +344,7 @@ eclib:
 eigen_abi_devel:
   - '5.0.1'
 elfutils:
-  - 0.189.memfault2
+  - 0.189.memfault3
 emela:
   - '1.0'
 exiv2:

--- a/gitleaks/meta.yaml
+++ b/gitleaks/meta.yaml
@@ -11,8 +11,10 @@ source:
   sha256: dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709 # [osx and x86_64]
   url: https://github.com/zricethezav/gitleaks/releases/download/v{{ version }}/gitleaks_{{ version }}_darwin_arm64.tar.gz # [osx and arm64]
   sha256: b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5 # [osx and arm64]
-  url: https://github.com/zricethezav/gitleaks/releases/download/v{{ version }}/gitleaks_{{ version }}_linux_x64.tar.gz # [linux64]
-  sha256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb # [linux64]
+  url: https://github.com/zricethezav/gitleaks/releases/download/v{{ version }}/gitleaks_{{ version }}_linux_x64.tar.gz # [linux and x86_64]
+  sha256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb # [linux and x86_64]
+  url: https://github.com/zricethezav/gitleaks/releases/download/v{{ version }}/gitleaks_{{ version }}_linux_arm64.tar.gz # [linux and aarch64]
+  sha256: e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080 # [linux and aarch64]
 
 build:
   string: '1'

--- a/memfault-ecs-cli/meta.yaml
+++ b/memfault-ecs-cli/meta.yaml
@@ -3,13 +3,15 @@
 
 package:
   name: {{ name }}
-  version: {{ version }}.memfault1
+  version: {{ version }}.memfault2
 
 source:
-  url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}.memfault1/ecs-cli.darwin-amd64 # [osx]
-  sha256: 4050e9aad0bb32a6b5d868e3e4d67b874eb1adb598d7214778555611ca2c934b # [osx]
-  url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}.memfault1/ecs-cli.linux-amd64 # [linux64]
-  sha256: c5bf1f19b869db6e94f9b331541bd7fcf2a559df22dd41428857dd73a0aae878 # [linux64]
+  url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}.memfault2/ecs-cli.darwin-amd64 # [osx]
+  sha256: 44cc90ceaaa792547380781747ab999b2dd3c9fb36a755d9ac5e3b468ab73326 # [osx]
+  url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}.memfault2/ecs-cli.linux-amd64 # [linux and x86_64]
+  sha256: d272eb81279f834e6c205eec0dda0a581c8982b02cbc9e0b0493ca2bbb93dd6a # [linux and x86_64]
+  url: https://github.com/memfault/memfault-ecs-cli/releases/download/{{ version }}.memfault2/ecs-cli.linux-arm64 # [linux and aarch64]
+  sha256: d84fa6db6017351725f6545797281835d4388668b120998146aa9190006271c5 # [linux and aarch64]
   fn: ecs-cli
 
 build:

--- a/overmind/meta.yaml
+++ b/overmind/meta.yaml
@@ -11,8 +11,10 @@ source:
   sha256: 58cc613d08bcb9b6c92b8b70e815d5dbb2ab9a30cfa6aa295ea796dc46ef1361                                            # [osx and x86_64]
   url: https://github.com/DarthSim/overmind/releases/download/v{{ version }}/overmind-v{{ version }}-macos-arm64.gz   # [osx and arm64]
   sha256: 04aa1dcf64b3d0272b51f49fd300ee346d0bd96e5cfc245121c8d56f2ffaac97                                            # [osx and arm64]
-  url: https://github.com/DarthSim/overmind/releases/download/v{{ version }}/overmind-v{{ version }}-linux-amd64.gz   # [linux64]
-  sha256: a17159b8e97d13f3679a4e8fbc9d4747f82d5af9f6d32597b72821378b5d0b6f                                            # [linux64]
+  url: https://github.com/DarthSim/overmind/releases/download/v{{ version }}/overmind-v{{ version }}-linux-amd64.gz   # [linux and x86_64]
+  sha256: a17159b8e97d13f3679a4e8fbc9d4747f82d5af9f6d32597b72821378b5d0b6f                                            # [linux and x86_64]
+  url: https://github.com/DarthSim/overmind/releases/download/v{{ version }}/overmind-v{{ version }}-linux-arm64.gz   # [linux and aarch64]
+  sha256: 42cb6d79c8adcf4c68dfb2ddf09e63a0803b023af5b17d42e05ccbfa4b86bee2                                            # [linux and aarch64]
 
 build:
   string: '1'

--- a/volta/meta.yaml
+++ b/volta/meta.yaml
@@ -7,11 +7,13 @@ package:
 
 source:
   # bash for getting the sigs:
-  # ❯ (_VER=2.0.2; for _arch in macos linux; do curl -sSL https://github.com/volta-cli/volta/releases/download/v${_VER}/volta-${_VER}-${_arch}.tar.gz | sha256sum; done)
+  # ❯ (_VER=2.0.2; for _arch in macos linux linux-arm; do curl -sSL https://github.com/volta-cli/volta/releases/download/v${_VER}/volta-${_VER}-${_arch}.tar.gz | sha256sum; done)
   url: https://github.com/volta-cli/volta/releases/download/v{{ version }}/volta-{{ version }}-macos.tar.gz # [osx]
   sha256: 57f7b51d6fb975f5c48b5ddf68f75103055e19fd822e3e2ce58d2be6ab78977d # [osx]
   url: https://github.com/volta-cli/volta/releases/download/v{{ version }}/volta-{{ version }}-linux.tar.gz # [linux and x86_64]
   sha256: 6cec054c911fb925b629a09455775af6e95dc0f5694a4c28b63979ab9ef18037 # [linux and x86_64]
+  url: https://github.com/volta-cli/volta/releases/download/v{{ version }}/volta-{{ version }}-linux-arm.tar.gz # [linux and aarch64]
+  sha256: 1eb92f8b711753aa576352b2e580b2f3fdadeab8664929ca1da3d0de65448517 # [linux and aarch64]
 
 build:
   string: '1'


### PR DESCRIPTION
Includes updates to support aarch64 in the following packages:

- clickhouse
- aws-vault
- overmind
- gitleaks
- gdb-multi-arch
- gdb-xtensa-esp32-elf
- memfault-ecs-cli
- volta